### PR TITLE
ci(release): set zip flag in windows upload step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,7 @@ jobs:
           target: |
             x86_64-pc-windows-msvc
             aarch64-pc-windows-msvc
-          zip
+          zip: true
           checksum: sha256
           include: README.md LICENSE docs/release-artifacts.md
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Fix workflow YAML by assigning a boolean to the zip option in the Windows release job, resolving the syntax error reported on line 71.