### PR TITLE
ci(workflows): add release dry-run builds and cache reuse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,3 +51,52 @@ jobs:
       - name: Build book
         run: mdbook build book
 
+  release-build-check:
+    name: Release build (dry run)
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            toolchain_targets: x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu
+            build_tool: cross
+            target_list: |
+              x86_64-unknown-linux-gnu
+              aarch64-unknown-linux-gnu
+          - os: macos-14
+            toolchain_targets: x86_64-apple-darwin,aarch64-apple-darwin
+            build_tool: cargo
+            target_list: |
+              x86_64-apple-darwin
+              aarch64-apple-darwin
+          - os: windows-latest
+            toolchain_targets: x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
+            build_tool: cargo
+            target_list: |
+              x86_64-pc-windows-msvc
+              aarch64-pc-windows-msvc
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.toolchain_targets }}
+      - uses: Swatinem/rust-cache@v2
+      - name: Install cross (Linux only)
+        if: matrix.build_tool == 'cross'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cross
+      - name: Build release binaries (no upload)
+        shell: bash
+        run: |
+          set -euo pipefail
+          cmd="cargo"
+          if [ "${{ matrix.build_tool }}" = "cross" ]; then
+            cmd="cross"
+          fi
+          while IFS= read -r target; do
+            [ -z "$target" ] && continue
+            echo "Building target $target with $cmd"
+            $cmd build --release --bin codex-mcp-skills --target "$target"
+          done <<< "${{ matrix.target_list }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,12 +12,18 @@ jobs:
   linux:
     name: Linux builds
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu
           components: clippy
+      - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@v2
         with:
           tool: cross
@@ -25,9 +31,8 @@ jobs:
         uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: codex-mcp-skills
-          target: |
-            x86_64-unknown-linux-gnu
-            aarch64-unknown-linux-gnu
+          target: ${{ matrix.target }}
+          build-tool: cross
           tar: unix
           zip: none
           checksum: sha256
@@ -37,18 +42,22 @@ jobs:
   macos:
     name: macOS builds
     runs-on: macos-14
+    strategy:
+      matrix:
+        target:
+          - aarch64-apple-darwin
+          - x86_64-apple-darwin
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: aarch64-apple-darwin,x86_64-apple-darwin
+      - uses: Swatinem/rust-cache@v2
       - name: Upload macOS binaries
         uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: codex-mcp-skills
-          target: |
-            aarch64-apple-darwin
-            x86_64-apple-darwin
+          target: ${{ matrix.target }}
           tar: unix
           zip: none
           checksum: sha256
@@ -58,18 +67,22 @@ jobs:
   windows:
     name: Windows builds
     runs-on: windows-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-pc-windows-msvc
+          - aarch64-pc-windows-msvc
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: x86_64-pc-windows-msvc,aarch64-pc-windows-msvc
+      - uses: Swatinem/rust-cache@v2
       - name: Upload Windows binaries
         uses: taiki-e/upload-rust-binary-action@v1
         with:
           bin: codex-mcp-skills
-          target: |
-            x86_64-pc-windows-msvc
-            aarch64-pc-windows-msvc
+          target: ${{ matrix.target }}
           tar: none
           zip: windows
           checksum: sha256


### PR DESCRIPTION
Add release-build-check job in CI to compile release targets on PRs using cross where needed, catching publish issues earlier.

Refactor release workflow to per-target matrices and enable rust-cache so Tagged builds rebuild quickly while keeping Linux cross builds explicit.