### PR TITLE
ci(workflows): fix include format for release uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,10 +36,7 @@ jobs:
           tar: unix
           zip: none
           checksum: sha256
-          include: |
-            README.md
-            LICENSE
-            docs/release-artifacts.md
+          include: LICENSE,README.md,docs/release-artifacts.md
           token: ${{ secrets.GITHUB_TOKEN }}
 
   macos:
@@ -64,10 +61,7 @@ jobs:
           tar: unix
           zip: none
           checksum: sha256
-          include: |
-            README.md
-            LICENSE
-            docs/release-artifacts.md
+          include: LICENSE,README.md,docs/release-artifacts.md
           token: ${{ secrets.GITHUB_TOKEN }}
 
   windows:
@@ -92,8 +86,5 @@ jobs:
           tar: none
           zip: windows
           checksum: sha256
-          include: |
-            README.md
-            LICENSE
-            docs/release-artifacts.md
+          include: LICENSE,README.md,docs/release-artifacts.md
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use the upload action's expected comma-separated include list so README, LICENSE, and docs/release-artifacts.md copy correctly into release artifacts across all platforms.