### PR TITLE
ci(release): create release before uploading assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,15 @@ permissions:
   contents: write
 
 jobs:
+  create-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
   linux:
     name: Linux builds
     runs-on: ubuntu-latest
@@ -17,6 +26,7 @@ jobs:
         target:
           - x86_64-unknown-linux-gnu
           - aarch64-unknown-linux-gnu
+    needs: create-release
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -47,6 +57,7 @@ jobs:
         target:
           - aarch64-apple-darwin
           - x86_64-apple-darwin
+    needs: create-release
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
@@ -72,6 +83,7 @@ jobs:
         target:
           - x86_64-pc-windows-msvc
           - aarch64-pc-windows-msvc
+    needs: create-release
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Add a create-release job and make Linux/macOS/Windows upload jobs depend on it so upload-rust-binary-action always has a GitHub release to attach artifacts to on tagged builds.