### PR TITLE
fix: revert sync crate name to skrills_sync for crates.io compatibility

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -230,7 +230,7 @@ jobs:
       - name: Run sync integration tests
         run: |
           echo "Running sync integration tests..."
-          cargo test -p skrills-sync --test sync_integration -- --nocapture
+          cargo test -p skrills_sync --test sync_integration -- --nocapture
           echo "Sync integration tests completed!"
 
   integration-test-summary:
@@ -289,7 +289,7 @@ jobs:
           cargo llvm-cov --lib --lcov --tests \
             -p skrills-server \
             -p skrills-subagents \
-            -p skrills-sync \
+            -p skrills_sync \
             -- \
             subagents_end_to_end \
             subagent_service_integration \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2213,8 +2213,8 @@ dependencies = [
  "skrills-intelligence",
  "skrills-state",
  "skrills-subagents",
- "skrills-sync",
  "skrills-validate",
+ "skrills_sync",
  "tempfile",
  "tokio",
  "tokio-util",
@@ -2264,7 +2264,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "skrills-sync"
+name = "skrills-validate"
+version = "0.4.6"
+dependencies = [
+ "anyhow",
+ "regex",
+ "semver",
+ "serde",
+ "serde_yaml",
+ "tempfile",
+ "thiserror",
+ "walkdir",
+]
+
+[[package]]
+name = "skrills_sync"
 version = "0.4.6"
 dependencies = [
  "anyhow",
@@ -2278,20 +2292,6 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "walkdir",
-]
-
-[[package]]
-name = "skrills-validate"
-version = "0.4.6"
-dependencies = [
- "anyhow",
- "regex",
- "semver",
- "serde",
- "serde_yaml",
- "tempfile",
- "thiserror",
  "walkdir",
 ]
 

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -44,7 +44,7 @@ skrills-subagents = { path = "../subagents", version = "0.4.5", optional = true 
 
 skrills-discovery = { path = "../discovery", version = "0.4.5" }
 skrills-state = { path = "../state", version = "0.4.5" }
-skrills-sync = { path = "../sync", version = "0.4.5" }
+skrills_sync = { path = "../sync", version = "0.4.5" }
 skrills-validate = { path = "../validate", version = "0.4.5" }
 skrills-analyze = { path = "../analyze", version = "0.4.5" }
 skrills-intelligence = { path = "../intelligence", version = "0.4.5" }

--- a/crates/sync/Cargo.toml
+++ b/crates/sync/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "skrills-sync"
+name = "skrills_sync"
 version = "0.4.6"
 edition.workspace = true
 description = "Preference synchronization and validation sync utilities for skrills"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -4,7 +4,7 @@
 - **Bug Fixes**: Address 14 issues including warnings for skipped optional dependencies, YAML line/column info in parse errors, SAFETY comments for regex patterns, and actionable hints for I/O errors.
 - **Testing**: Add 282 new tests across claude_parser, codex_parser, context detector, github_search, dependencies, llm_generator, and scorer modules.
 - **Documentation**: Add comprehensive audit-logging.md covering security events, mTLS audit trails, and SIEM integration.
-- **CI**: Update workflow to use skrills-sync package name after crate rename.
+- **CI**: Revert sync crate name to skrills_sync (crates.io disallows renaming published crates).
 - **Build**: Add fmt-check target to catch formatting issues in pre-commit hooks.
 
 ## 0.4.5 - 2026-01-03

--- a/scripts/publish_crates.sh
+++ b/scripts/publish_crates.sh
@@ -51,7 +51,7 @@ publish_one skrills-discovery
 publish_one skrills-intelligence
 
 # Level 1: depend on leaf crates only
-publish_one skrills-sync
+publish_one skrills_sync
 publish_one skrills-subagents
 publish_one skrills-analyze
 


### PR DESCRIPTION
## Summary
- Reverts sync crate name from `skrills-sync` back to `skrills_sync`
- crates.io does not allow renaming published crates

## Problem
Publishing v0.4.6 failed with:
> crate was previously named `skrills_sync`

## Changes
- `crates/sync/Cargo.toml` - reverted name field
- `crates/server/Cargo.toml` - reverted dependency reference
- `.github/workflows/integration-tests.yml` - reverted test commands
- `scripts/publish_crates.sh` - reverted publish command
- `docs/CHANGELOG.md` - updated CI note

## Related
- Issue #95 tracks the crates.io rename request
- Email draft in `CRATES_IO_EMAIL.md` (not committed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)