### PR TITLE
chore: bump version to 0.4.7

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2124,7 +2124,7 @@ checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "skrills"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "scopeguard",
@@ -2134,7 +2134,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-analyze"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "parking_lot",
@@ -2151,7 +2151,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-discovery"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2166,7 +2166,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-intelligence"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2187,7 +2187,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-server"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "axum",
@@ -2228,7 +2228,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-state"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2239,7 +2239,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-subagents"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2265,7 +2265,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-validate"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "regex",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "skrills_sync"
-version = "0.4.6"
+version = "0.4.7"
 dependencies = [
  "anyhow",
  "dirs",

--- a/crates/analyze/Cargo.toml
+++ b/crates/analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-analyze"
-version = "0.4.6"
+version = "0.4.7"
 edition.workspace = true
 description = "Skill analysis: token counting, dependencies, and optimization"
 license = "MIT"
@@ -19,8 +19,8 @@ anyhow = { workspace = true }
 walkdir = { workspace = true }
 thiserror = { workspace = true }
 semver = { workspace = true }
-skrills-validate = { path = "../validate", version = "0.4.5" }
-skrills-discovery = { path = "../discovery", version = "0.4.5" }
+skrills-validate = { path = "../validate", version = "0.4.7" }
+skrills-discovery = { path = "../discovery", version = "0.4.7" }
 parking_lot = { workspace = true }
 
 [dev-dependencies]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 description = "A command-line interface and MCP server for managing local SKILL.md files."
 license = "MIT"
@@ -19,7 +19,7 @@ subagents = ["skrills-server/subagents"]
 http-transport = ["skrills-server/http-transport"]
 
 [dependencies]
-skrills-server = { path = "../server", version = "0.4.5" }
+skrills-server = { path = "../server", version = "0.4.7" }
 anyhow.workspace = true
 
 [dev-dependencies]

--- a/crates/discovery/Cargo.toml
+++ b/crates/discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-discovery"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 description = "Filesystem discovery and hashing utilities used by the skrills MCP server."
 license = "MIT"

--- a/crates/intelligence/Cargo.toml
+++ b/crates/intelligence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-intelligence"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 description = "Intelligent skill recommendations based on usage patterns and project context."
 license = "MIT"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-server"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 description = "Core library for the skrills MCP server: discovery, filtering, manifest generation, and runtime control."
 license = "MIT"
@@ -40,14 +40,14 @@ parking_lot.workspace = true
 axum = { version = "0.8", optional = true }
 tower = { version = "0.5", optional = true }
 
-skrills-subagents = { path = "../subagents", version = "0.4.5", optional = true }
+skrills-subagents = { path = "../subagents", version = "0.4.7", optional = true }
 
-skrills-discovery = { path = "../discovery", version = "0.4.5" }
-skrills-state = { path = "../state", version = "0.4.5" }
-skrills_sync = { path = "../sync", version = "0.4.5" }
-skrills-validate = { path = "../validate", version = "0.4.5" }
-skrills-analyze = { path = "../analyze", version = "0.4.5" }
-skrills-intelligence = { path = "../intelligence", version = "0.4.5" }
+skrills-discovery = { path = "../discovery", version = "0.4.7" }
+skrills-state = { path = "../state", version = "0.4.7" }
+skrills_sync = { path = "../sync", version = "0.4.7" }
+skrills-validate = { path = "../validate", version = "0.4.7" }
+skrills-analyze = { path = "../analyze", version = "0.4.7" }
+skrills-intelligence = { path = "../intelligence", version = "0.4.7" }
 shellexpand = "3"
 
 [features]

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-state"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 description = "State management for skrills runtime options, pins, and persisted overrides."
 license = "MIT"

--- a/crates/subagents/Cargo.toml
+++ b/crates/subagents/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-subagents"
-version = "0.4.6"
+version = "0.4.7"
 edition = "2021"
 description = "Subagent MCP tools for the skrills server with pluggable backends."
 license = "MIT"
@@ -29,8 +29,8 @@ tempfile.workspace = true
 parking_lot.workspace = true
 toml.workspace = true
 
-skrills-discovery = { path = "../discovery", version = "0.4.5" }
-skrills-state = { path = "../state", version = "0.4.5" }
+skrills-discovery = { path = "../discovery", version = "0.4.7" }
+skrills-state = { path = "../state", version = "0.4.7" }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/crates/sync/Cargo.toml
+++ b/crates/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills_sync"
-version = "0.4.6"
+version = "0.4.7"
 edition.workspace = true
 description = "Preference synchronization and validation sync utilities for skrills"
 license = "MIT"
@@ -20,7 +20,7 @@ walkdir.workspace = true
 dirs.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-skrills-validate = { path = "../validate", version = "0.4.5" }
+skrills-validate = { path = "../validate", version = "0.4.7" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/validate/Cargo.toml
+++ b/crates/validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-validate"
-version = "0.4.6"
+version = "0.4.7"
 edition.workspace = true
 description = "Skill validation for Claude Code and Codex CLI"
 license = "MIT"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.4.7 - 2026-01-09
+- **Chore**: Version bump to republish after v0.4.6 tag protection issue.
+- All changes from 0.4.6 are included in this release.
+
 ## 0.4.6 - 2026-01-08
 - **Bug Fixes**: Address 14 issues including warnings for skipped optional dependencies, YAML line/column info in parse errors, SAFETY comments for regex patterns, and actionable hints for I/O errors.
 - **Testing**: Add 282 new tests across claude_parser, codex_parser, context detector, github_search, dependencies, llm_generator, and scorer modules.


### PR DESCRIPTION
## Summary
Version bump to 0.4.7 to republish after v0.4.6 tag could not be deleted due to GitHub repository protection rules.

## Changes
- Bumped all crate versions from 0.4.6 → 0.4.7
- Bumped all internal dependency versions to 0.4.7
- Added 0.4.7 entry to CHANGELOG

## Included from 0.4.6
All changes from the 0.4.6 release are included:
- Bug fixes for 14 issues
- 282 new tests across multiple modules
- audit-logging.md documentation
- Reverted sync crate name to `skrills_sync` (crates.io compatibility)
- fmt-check target for pre-commit hooks

## After Merge
1. Create tag: `git tag -a v0.4.7 <merge-commit> -m "v0.4.7"`
2. Push tag: `git push origin v0.4.7`
3. CI will publish to crates.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)