### PR TITLE
chore: bump version to 0.4.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2231,7 +2231,7 @@ checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "skrills"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "scopeguard",
@@ -2241,7 +2241,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-analyze"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "parking_lot",
@@ -2258,7 +2258,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-discovery"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "blake2",
@@ -2274,7 +2274,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-intelligence"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "chrono",
@@ -2295,7 +2295,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-server"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "axum",
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-state"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "dirs",
@@ -2350,7 +2350,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-subagents"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2376,7 +2376,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-validate"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "regex",
@@ -2390,7 +2390,7 @@ dependencies = [
 
 [[package]]
 name = "skrills_sync"
-version = "0.4.10"
+version = "0.4.11"
 dependencies = [
  "anyhow",
  "dirs",

--- a/crates/analyze/Cargo.toml
+++ b/crates/analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-analyze"
-version = "0.4.10"
+version = "0.4.11"
 edition.workspace = true
 description = "Skill analysis: token counting, dependencies, and optimization"
 license = "MIT"
@@ -19,8 +19,8 @@ anyhow = { workspace = true }
 walkdir = { workspace = true }
 thiserror = { workspace = true }
 semver = { workspace = true }
-skrills-validate = { path = "../validate", version = "0.4.10" }
-skrills-discovery = { path = "../discovery", version = "0.4.10" }
+skrills-validate = { path = "../validate", version = "0.4.11" }
+skrills-discovery = { path = "../discovery", version = "0.4.11" }
 parking_lot = { workspace = true }
 
 [dev-dependencies]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "A command-line interface and MCP server for managing local SKILL.md files."
 license = "MIT"
@@ -19,7 +19,7 @@ subagents = ["skrills-server/subagents"]
 http-transport = ["skrills-server/http-transport"]
 
 [dependencies]
-skrills-server = { path = "../server", version = "0.4.10" }
+skrills-server = { path = "../server", version = "0.4.11" }
 anyhow.workspace = true
 
 [dev-dependencies]

--- a/crates/discovery/Cargo.toml
+++ b/crates/discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-discovery"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Filesystem discovery and hashing utilities used by the skrills MCP server."
 license = "MIT"

--- a/crates/intelligence/Cargo.toml
+++ b/crates/intelligence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-intelligence"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Intelligent skill recommendations based on usage patterns and project context."
 license = "MIT"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-server"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Core library for the skrills MCP server: discovery, filtering, manifest generation, and runtime control."
 license = "MIT"
@@ -43,14 +43,14 @@ axum-server = { version = "0.7", features = ["tls-rustls"], optional = true }
 tower = { version = "0.5", optional = true }
 tower-http = { version = "0.6", features = ["cors"], optional = true }
 
-skrills-subagents = { path = "../subagents", version = "0.4.10", optional = true }
+skrills-subagents = { path = "../subagents", version = "0.4.11", optional = true }
 
-skrills-discovery = { path = "../discovery", version = "0.4.10" }
-skrills-state = { path = "../state", version = "0.4.10" }
-skrills_sync = { path = "../sync", version = "0.4.10" }
-skrills-validate = { path = "../validate", version = "0.4.10" }
-skrills-analyze = { path = "../analyze", version = "0.4.10" }
-skrills-intelligence = { path = "../intelligence", version = "0.4.10" }
+skrills-discovery = { path = "../discovery", version = "0.4.11" }
+skrills-state = { path = "../state", version = "0.4.11" }
+skrills_sync = { path = "../sync", version = "0.4.11" }
+skrills-validate = { path = "../validate", version = "0.4.11" }
+skrills-analyze = { path = "../analyze", version = "0.4.11" }
+skrills-intelligence = { path = "../intelligence", version = "0.4.11" }
 shellexpand = "3"
 
 [features]

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-state"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "State management for skrills runtime options, pins, and persisted overrides."
 license = "MIT"

--- a/crates/subagents/Cargo.toml
+++ b/crates/subagents/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-subagents"
-version = "0.4.10"
+version = "0.4.11"
 edition = "2021"
 description = "Subagent MCP tools for the skrills server with pluggable backends."
 license = "MIT"
@@ -29,8 +29,8 @@ tempfile.workspace = true
 parking_lot.workspace = true
 toml.workspace = true
 
-skrills-discovery = { path = "../discovery", version = "0.4.10" }
-skrills-state = { path = "../state", version = "0.4.10" }
+skrills-discovery = { path = "../discovery", version = "0.4.11" }
+skrills-state = { path = "../state", version = "0.4.11" }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/crates/sync/Cargo.toml
+++ b/crates/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills_sync"
-version = "0.4.10"
+version = "0.4.11"
 edition.workspace = true
 description = "Preference synchronization and validation sync utilities for skrills"
 license = "MIT"
@@ -20,7 +20,7 @@ walkdir.workspace = true
 dirs.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
-skrills-validate = { path = "../validate", version = "0.4.10" }
+skrills-validate = { path = "../validate", version = "0.4.11" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/validate/Cargo.toml
+++ b/crates/validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-validate"
-version = "0.4.10"
+version = "0.4.11"
 edition.workspace = true
 description = "Skill validation for Claude Code and Codex CLI"
 license = "MIT"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,7 +2,14 @@
 
 ## Unreleased
 
-- **Testing**: Added 2 cluster formation tests for empirical skill creation covering session clustering by tool patterns and meaningful label assignment.
+## 0.4.11 - 2026-01-15
+- **Refactor**: Improved test infrastructure with RAII guards (`EnvVarGuard`, `TestFixture`) for reliable parallel test execution.
+- **Refactor**: Extracted API key error messages to constants in subagent backends.
+- **Bug Fix**: Added logging for silent failure path in skill validation invariant checks.
+- **Bug Fix**: Changed timestamp duration calculation to use `saturating_mul` to prevent integer overflow.
+- **Docs**: Consolidated 14 documentation files from bulleted lists to flowing prose, reducing visual noise while preserving technical content.
+- **Docs**: Added missing `skip_existing_commands` parameter to `sync_all_tool` documentation.
+- **Testing**: Added 27 new tests covering cluster formation, deviation score boundaries, n-gram edge cases, behavioral patterns, and parse_trace_target case sensitivity.
 
 ## 0.4.10 - 2026-01-15
 - **NEW: Confidence Type**: Added `Confidence` newtype with clamping constructor (0.0-1.0) for type-safe confidence scores in recommendations. (#73)


### PR DESCRIPTION
Update all workspace crate versions from 0.4.10 to 0.4.11 and add changelog entry documenting the release contents:

- RAII test infrastructure improvements
- Bug fixes for silent failures and integer overflow
- Documentation consolidation and improvements
- 27 new tests for coverage gaps