### PR TITLE
Release 0.7.4: research MCP tools and version bump

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4391,6 +4391,7 @@ dependencies = [
  "skrills-metrics",
  "skrills-state",
  "skrills-subagents",
+ "skrills-tome",
  "skrills-validate",
  "skrills_sync",
  "skrills_test_utils",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.0"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa7e52a4c5c547c741610a2c6f123f3881e409b714cd27e6798ef020c514f0a"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
 dependencies = [
  "cc",
  "cmake",
@@ -505,9 +505,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.57"
+version = "1.2.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a0dd1ca384932ff3641c8718a02769f1698e7563dc6974ffd03346116310423"
+checksum = "e1e928d4b69e3077709075a938a05ffbedfa53a84c8f766efbf8220bb1ff60e1"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -653,9 +653,9 @@ checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cmake"
-version = "0.1.57"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75443c44cd6b379beb8c5b45d85d0773baf31cce901fe7bb252f4eff3008ef7d"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]
@@ -742,20 +742,19 @@ dependencies = [
  "convert_case 0.6.0",
  "pathdiff",
  "serde_core",
- "toml 1.1.0+spec-1.1.0",
- "winnow 1.0.0",
+ "toml 1.1.2+spec-1.1.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "console"
-version = "0.15.11"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "once_cell",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1337,9 +1336,12 @@ dependencies = [
 
 [[package]]
 name = "fragile"
-version = "2.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28dd6caf6059519a65843af8fe2a3ae298b14b80179855aeb4adc2c1934ee619"
+checksum = "8878864ba14bb86e818a412bfd6f18f9eabd4ec0f008a28e8f7eb61db532fcf9"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "fs-err"
@@ -1709,9 +1711,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1724,7 +1726,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1795,12 +1796,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1808,9 +1810,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1821,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1835,15 +1837,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1855,15 +1857,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1964,9 +1966,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.46.3"
+version = "1.47.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e82db8c87c7f1ccecb34ce0c24399b8a73081427f3c7c50a5d597925356115e4"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
 dependencies = [
  "console",
  "once_cell",
@@ -1995,9 +1997,9 @@ checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
 
 [[package]]
 name = "inventory"
-version = "0.3.22"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "009ae045c87e7082cb72dab0ccd01ae075dd00141ddc108f43a0ea150a9e7227"
+checksum = "a4f0c30c76f2f4ccee3fe55a2435f691ca00c0e4bd87abe4f4a851b1d4dac39b"
 dependencies = [
  "rustversion",
 ]
@@ -2010,9 +2012,9 @@ checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "iri-string"
-version = "0.7.11"
+version = "0.7.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8e7418f59cc01c88316161279a7f665217ae316b388e58a0d10e29f54f1e5eb"
+checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
 dependencies = [
  "memchr",
  "serde",
@@ -2095,10 +2097,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49715b7073f385ba4bc528e5747d02e66cb39c6146efb66b781f131f0fb399c"
+checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
 dependencies = [
+ "cfg-if",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2371,9 +2375,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.183"
+version = "0.2.184"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libredox"
@@ -2397,9 +2401,9 @@ dependencies = [
 
 [[package]]
 name = "line-clipping"
-version = "0.3.5"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -2418,9 +2422,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "litrs"
@@ -2567,9 +2571,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "log",
@@ -2995,12 +2999,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pin-utils"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3014,9 +3012,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -3712,9 +3710,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -4036,9 +4034,9 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "1.1.0"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "876ac351060d4f882bb1032b6369eb0aef79ad9df1ea8bc404874d8cc3d0cd98"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
 ]
@@ -4233,9 +4231,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "similar"
@@ -4251,7 +4249,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skrills"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "scopeguard",
@@ -4262,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-analyze"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "parking_lot",
  "regex",
@@ -4279,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-dashboard"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -4299,7 +4297,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-discovery"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4316,7 +4314,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-intelligence"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4338,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-metrics"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4354,7 +4352,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-server"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4412,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-state"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4424,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-subagents"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4451,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-tome"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4470,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-validate"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "proptest",
@@ -4485,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "skrills_sync"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4504,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "skrills_test_utils"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "tempfile",
 ]
@@ -4879,9 +4877,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4978,15 +4976,15 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8195ca05e4eb728f4ba94f3e3291661320af739c4e43779cbdfae82ab239fcc"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
  "serde_core",
- "serde_spanned 1.1.0",
- "toml_datetime 1.1.0+spec-1.1.0",
+ "serde_spanned 1.1.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -5000,9 +4998,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97251a7c317e03ad83774a8752a7e81fb6067740609f75ea2b585b569a59198f"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -5023,11 +5021,11 @@ dependencies = [
 
 [[package]]
 name = "toml_parser"
-version = "1.1.0+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2334f11ee363607eb04df9b8fc8a13ca1715a72ba8662a26ac285c98aabb4011"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.0",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -5226,9 +5224,9 @@ checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.13.1"
+version = "1.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da36089a805484bcccfffe0739803392c8298778a2d2f09febf76fac5ad9025b"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-truncate"
@@ -5303,9 +5301,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.22.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a68d3c8f01c0cfa54a75291d83601161799e4a89a39e0929f4b0354d88757a37"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
  "atomic",
  "getrandom 0.4.2",
@@ -5389,9 +5387,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6532f9a5c1ece3798cb1c2cfdba640b9b3ba884f5db45973a6f442510a87d38e"
+checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -5402,23 +5400,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.64"
+version = "0.4.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9c5522b3a28661442748e09d40924dfb9ca614b21c00d3fd135720e48b67db8"
+checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
 dependencies = [
- "cfg-if",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18a2d50fcf105fb33bb15f00e7a77b772945a2ee45dcf454961fd843e74c18e6"
+checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5426,9 +5420,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03ce4caeaac547cdf713d280eda22a730824dd11e6b8c3ca9e42247b25c631e3"
+checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5439,9 +5433,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.114"
+version = "0.2.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75a326b8c223ee17883a4251907455a2431acc2791c98c26279376490c378c16"
+checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -5508,9 +5502,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.91"
+version = "0.3.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854ba17bb104abfb26ba36da9729addc7ce7f06f5c0f90f3c391f8461cca21f9"
+checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5817,15 +5811,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.60.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
@@ -6048,9 +6033,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90e88e4667264a994d34e6d1ab2d26d398dcdca8b7f52bec8668957517fc7d8"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -6213,9 +6198,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6224,9 +6209,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6236,18 +6221,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.47"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6256,18 +6241,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6283,9 +6268,9 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6294,9 +6279,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6305,9 +6290,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 [![Coverage](https://img.shields.io/github/actions/workflow/status/athola/skrills/coverage.yml?branch=master&label=coverage)](https://github.com/athola/skrills/actions/workflows/coverage.yml)
 [![Audit](https://img.shields.io/github/actions/workflow/status/athola/skrills/audit.yml?branch=master&label=audit)](https://github.com/athola/skrills/actions/workflows/audit.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+[![Mentioned in Awesome Codex CLI](https://awesome.re/mentioned-badge.svg)](https://github.com/RoggeOhta/awesome-codex-cli)
 
 Skills support engine for Claude Code, Codex CLI, GitHub Copilot CLI,
 and Cursor.

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ and Cursor.
 [FAQ](docs/FAQ.md) |
 [Changelog](book/src/changelog.md)
 
-> **What's new in 0.7.3** -- MCP tool filtering
-> (`allowed_tools`/`disabled_tools`) synced across all adapters,
-> MCP servers panel in TUI and browser dashboards,
-> `/api/mcp-servers` REST endpoint, configurable Unpaywall email,
-> `OffsetDateTime` for discussion timestamps, and SQL upsert fix.
+> **What's new in 0.7.4** -- 9 research MCP tools
+> (`search-papers`, `search-discussions`, `resolve-doi`, `fetch-pdf`,
+> `query-knowledge-graph`, `add-knowledge-node`, `link-knowledge`,
+> `track-citations`, `resolve-contradiction`) exposing the `tome`
+> crate over MCP (27 → 36 tools total).
 > See [changelog](book/src/changelog.md).
 
 ## Demo
@@ -57,8 +57,9 @@ setup.
   reductions to fit context windows.
 - **Dependency resolution** -- resolves skill dependencies with cycle
   detection and semantic versioning constraints.
-- **MCP server** -- 27 tools for validation, sync, intelligence, and
-  project-aware skill generation over stdio or HTTP transport.
+- **MCP server** -- 36 tools for validation, sync, intelligence,
+  research, and project-aware skill generation over stdio or HTTP
+  transport.
 - **Session mining** -- parses Claude Code and Codex CLI session
   history to improve recommendations based on actual usage.
 - **Visualization** -- TUI and browser dashboard showing discovered

--- a/book/src/changelog.md
+++ b/book/src/changelog.md
@@ -1,5 +1,10 @@
 # Changelog Highlights
 
+## 0.7.4 (2026-04-02)
+
+- **NEW: Research MCP Tools**: 9 tools expose the `tome` crate over MCP -- `search-papers`, `search-discussions`, `resolve-doi`, `fetch-pdf`, `query-knowledge-graph`, `add-knowledge-node`, `link-knowledge`, `track-citations`, `resolve-contradiction` (27 → 36 tools).
+- **Fix: Paper Model**: Refined `Paper` model fields and research handler argument parsing.
+
 ## 0.7.3 (2026-03-29)
 
 - **NEW: MCP Tool Filtering**: `allowed_tools`/`disabled_tools` fields on `McpServer` synced across all four adapters.

--- a/book/src/cli.md
+++ b/book/src/cli.md
@@ -152,7 +152,7 @@ skrills serve --skill-dir ~/.custom/skills  # Custom skill directory
 | `--cache-ttl-ms <N>` | Discovery cache TTL in milliseconds |
 | `--watch` | Enable live filesystem invalidation |
 
-The MCP server exposes 27 tools for validation, analysis, sync, intelligence, and research directly to your AI assistant. The HTTP mode serves a browser dashboard with skills explorer, metrics, and activity feed.
+The MCP server exposes 36 tools for validation, analysis, sync, intelligence, and research directly to your AI assistant. The HTTP mode serves a browser dashboard with skills explorer, metrics, and activity feed.
 
 Skrills also ships a self-contained HTML portal (`skrills-portal.html`) that works offline without a running server. It includes a skills browser, validator with autofix, token analyzer, cross-CLI converter, and full CLI/MCP reference. Open it directly in any browser or upload it into AI application portals.
 

--- a/crates/analyze/Cargo.toml
+++ b/crates/analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-analyze"
-version = "0.7.3"
+version = "0.7.4"
 edition.workspace = true
 description = "Skill analysis: token counting, dependencies, and optimization"
 license = "MIT"
@@ -19,8 +19,8 @@ walkdir = { workspace = true }
 thiserror = { workspace = true }
 semver = { workspace = true }
 tracing = { workspace = true }
-skrills-validate = { path = "../validate", version = "0.7.3" }
-skrills-discovery = { path = "../discovery", version = "0.7.3" }
+skrills-validate = { path = "../validate", version = "0.7.4" }
+skrills-discovery = { path = "../discovery", version = "0.7.4" }
 parking_lot = { workspace = true }
 
 [dev-dependencies]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 description = "A command-line interface and MCP server for managing local SKILL.md files."
 license = "MIT"
@@ -19,7 +19,7 @@ subagents = ["skrills-server/subagents"]
 http-transport = ["skrills-server/http-transport"]
 
 [dependencies]
-skrills-server = { path = "../server", version = "0.7.3" }
+skrills-server = { path = "../server", version = "0.7.4" }
 anyhow.workspace = true
 
 [dev-dependencies]

--- a/crates/dashboard/Cargo.toml
+++ b/crates/dashboard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-dashboard"
-version = "0.7.3"
+version = "0.7.4"
 edition.workspace = true
 description = "Terminal UI dashboard for skrills metrics and monitoring"
 license = "MIT"
@@ -13,9 +13,9 @@ categories = ["development-tools", "visualization"]
 publish = true
 
 [dependencies]
-skrills-metrics = { path = "../metrics", version = "0.7.3" }
-skrills-discovery = { path = "../discovery", version = "0.7.3" }
-skrills_sync = { path = "../sync", version = "0.7.3" }
+skrills-metrics = { path = "../metrics", version = "0.7.4" }
+skrills-discovery = { path = "../discovery", version = "0.7.4" }
+skrills_sync = { path = "../sync", version = "0.7.4" }
 
 # TUI
 ratatui = "0.30"

--- a/crates/discovery/Cargo.toml
+++ b/crates/discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-discovery"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 description = "Filesystem discovery and hashing utilities used by the skrills MCP server."
 license = "MIT"

--- a/crates/intelligence/Cargo.toml
+++ b/crates/intelligence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-intelligence"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 description = "Intelligent skill recommendations based on usage patterns and project context."
 license = "MIT"

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-metrics"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 description = "SQLite-based metrics collection for skrills skill invocations, validations, and sync events."
 license = "MIT"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-server"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 description = "Core library for the skrills MCP server: discovery, filtering, manifest generation, and runtime control."
 license = "MIT"
@@ -45,18 +45,18 @@ rcgen = { version = "0.14", optional = true }
 x509-parser = { version = "0.18", optional = true }
 time.workspace = true
 
-skrills-subagents = { path = "../subagents", version = "0.7.3", optional = true }
+skrills-subagents = { path = "../subagents", version = "0.7.4", optional = true }
 
-skrills-discovery = { path = "../discovery", version = "0.7.3" }
-skrills-state = { path = "../state", version = "0.7.3" }
-skrills_sync = { path = "../sync", version = "0.7.3" }
-skrills-validate = { path = "../validate", version = "0.7.3" }
-skrills-analyze = { path = "../analyze", version = "0.7.3" }
-skrills-intelligence = { path = "../intelligence", version = "0.7.3" }
-skrills-metrics = { path = "../metrics", version = "0.7.3" }
-skrills-tome = { path = "../tome", version = "0.7.3" }
+skrills-discovery = { path = "../discovery", version = "0.7.4" }
+skrills-state = { path = "../state", version = "0.7.4" }
+skrills_sync = { path = "../sync", version = "0.7.4" }
+skrills-validate = { path = "../validate", version = "0.7.4" }
+skrills-analyze = { path = "../analyze", version = "0.7.4" }
+skrills-intelligence = { path = "../intelligence", version = "0.7.4" }
+skrills-metrics = { path = "../metrics", version = "0.7.4" }
+skrills-tome = { path = "../tome", version = "0.7.4" }
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
-skrills-dashboard = { path = "../dashboard", version = "0.7.3", optional = true }
+skrills-dashboard = { path = "../dashboard", version = "0.7.4", optional = true }
 shellexpand = "3"
 regex = "1"
 sha2.workspace = true

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -54,6 +54,8 @@ skrills-validate = { path = "../validate", version = "0.7.3" }
 skrills-analyze = { path = "../analyze", version = "0.7.3" }
 skrills-intelligence = { path = "../intelligence", version = "0.7.3" }
 skrills-metrics = { path = "../metrics", version = "0.7.3" }
+skrills-tome = { path = "../tome", version = "0.7.3" }
+reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
 skrills-dashboard = { path = "../dashboard", version = "0.7.3", optional = true }
 shellexpand = "3"
 regex = "1"

--- a/crates/server/src/app/mod.rs
+++ b/crates/server/src/app/mod.rs
@@ -13,6 +13,7 @@
 //! Keep this file under ~2500 LOC; split modules if needed.
 
 mod intelligence;
+mod research;
 mod tools;
 
 #[cfg(test)]

--- a/crates/server/src/app/research.rs
+++ b/crates/server/src/app/research.rs
@@ -1,0 +1,642 @@
+//! Research tool handlers for the tome crate.
+//!
+//! Implements MCP tool handlers for academic research API orchestration,
+//! knowledge graph management, citation tracking, and TRIZ contradiction resolution.
+
+use anyhow::{anyhow, Result};
+use rmcp::model::{CallToolResult, Content};
+use serde_json::{json, Map as JsonMap, Value};
+
+use crate::app::SkillService;
+
+/// Resolve the skrills-tome cache directory.
+///
+/// Mirrors the logic in `ResearchCache::open()` so that the knowledge graph
+/// and citation databases land alongside the API cache.
+fn tome_cache_dir() -> Result<std::path::PathBuf> {
+    let base = dirs::cache_dir()
+        .or_else(|| dirs::home_dir().map(|h| h.join(".cache")))
+        .ok_or_else(|| anyhow!("cannot determine cache directory: HOME is unset"))?;
+    let dir = base.join("skrills-tome");
+    std::fs::create_dir_all(&dir)?;
+    Ok(dir)
+}
+
+impl SkillService {
+    // --- #168: Research API Tools ---
+
+    pub(crate) async fn search_papers_tool(
+        &self,
+        args: JsonMap<String, Value>,
+    ) -> Result<CallToolResult> {
+        use skrills_tome::clients::arxiv::ArxivClient;
+        use skrills_tome::clients::openalex::OpenAlexClient;
+        use skrills_tome::clients::semantic_scholar::SemanticScholarClient;
+        use skrills_tome::models::Paper;
+        use std::collections::HashSet;
+
+        let query = args
+            .get("query")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing required parameter: query"))?;
+        let limit = args
+            .get("limit")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(10)
+            .min(100) as usize;
+        let sources: Vec<String> = args
+            .get("sources")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_else(|| {
+                vec![
+                    "arxiv".to_string(),
+                    "semantic_scholar".to_string(),
+                    "openalex".to_string(),
+                ]
+            });
+
+        let mut all_papers: Vec<Paper> = Vec::new();
+        let mut errors: Vec<String> = Vec::new();
+
+        for source in &sources {
+            let result: Result<Vec<Paper>, _> = match source.as_str() {
+                "arxiv" => ArxivClient::new().search(query, limit).await,
+                "semantic_scholar" => SemanticScholarClient::new().search(query, limit).await,
+                "openalex" => OpenAlexClient::new().search(query, limit).await,
+                other => {
+                    errors.push(format!("Unknown source: {other}"));
+                    continue;
+                }
+            };
+            match result {
+                Ok(papers) => all_papers.extend(papers),
+                Err(e) => errors.push(format!("{source}: {e}")),
+            }
+        }
+
+        // Deduplicate by DOI
+        let mut seen_dois = HashSet::new();
+        let mut deduped: Vec<Paper> = Vec::new();
+        for paper in all_papers {
+            if let Some(doi) = &paper.doi {
+                if !seen_dois.insert(doi.clone()) {
+                    continue;
+                }
+            }
+            deduped.push(paper);
+        }
+        deduped.truncate(limit);
+
+        let paper_json: Vec<Value> = deduped
+            .iter()
+            .map(|p| {
+                json!({
+                    "id": p.id,
+                    "title": p.title,
+                    "authors": p.authors,
+                    "abstract": p.abstract_text,
+                    "year": p.year,
+                    "doi": p.doi,
+                    "url": p.url,
+                    "source": p.source,
+                    "citation_count": p.citation_count,
+                    "pdf_url": p.pdf_url,
+                })
+            })
+            .collect();
+
+        let mut text = format!("Found {} papers", deduped.len());
+        if !errors.is_empty() {
+            text.push_str(&format!(" ({} source errors)", errors.len()));
+        }
+
+        Ok(CallToolResult {
+            content: vec![Content::text(text)],
+            structured_content: Some(json!({
+                "papers": paper_json,
+                "count": deduped.len(),
+                "errors": errors,
+            })),
+            is_error: Some(false),
+            meta: None,
+        })
+    }
+
+    pub(crate) async fn search_discussions_tool(
+        &self,
+        args: JsonMap<String, Value>,
+    ) -> Result<CallToolResult> {
+        use skrills_tome::clients::hn_algolia::HnAlgoliaClient;
+
+        let query = args
+            .get("query")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing required parameter: query"))?;
+        let limit = args
+            .get("limit")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(10) as usize;
+
+        let client = HnAlgoliaClient::new();
+        let discussions = client.search(query, limit).await?;
+
+        let discussion_json: Vec<Value> = discussions
+            .iter()
+            .map(|d| {
+                json!({
+                    "id": d.id,
+                    "title": d.title,
+                    "url": d.url,
+                    "points": d.points,
+                    "comment_count": d.comment_count,
+                    "source": d.source,
+                    "created_at": d.created_at.map(|t| {
+                        t.format(&time::format_description::well_known::Rfc3339)
+                            .unwrap_or_default()
+                    }),
+                })
+            })
+            .collect();
+
+        Ok(CallToolResult {
+            content: vec![Content::text(format!(
+                "Found {} discussions",
+                discussions.len()
+            ))],
+            structured_content: Some(json!({
+                "discussions": discussion_json,
+                "count": discussions.len(),
+            })),
+            is_error: Some(false),
+            meta: None,
+        })
+    }
+
+    pub(crate) async fn resolve_doi_tool(
+        &self,
+        args: JsonMap<String, Value>,
+    ) -> Result<CallToolResult> {
+        use skrills_tome::clients::crossref::CrossRefClient;
+        use skrills_tome::clients::unpaywall::UnpaywallClient;
+
+        let doi = args
+            .get("doi")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing required parameter: doi"))?;
+
+        let crossref = CrossRefClient::new();
+        let metadata = crossref.resolve_doi(doi).await?;
+
+        let unpaywall = UnpaywallClient::default();
+        let pdf_url = unpaywall.find_pdf_url(doi).await.unwrap_or(None);
+
+        Ok(CallToolResult {
+            content: vec![Content::text(format!(
+                "{} ({})",
+                metadata.title,
+                metadata.year.map(|y| y.to_string()).unwrap_or_default()
+            ))],
+            structured_content: Some(json!({
+                "doi": metadata.doi,
+                "title": metadata.title,
+                "authors": metadata.authors,
+                "publisher": metadata.publisher,
+                "year": metadata.year,
+                "url": metadata.url,
+                "journal": metadata.journal,
+                "pdf_url": pdf_url,
+            })),
+            is_error: Some(false),
+            meta: None,
+        })
+    }
+
+    pub(crate) async fn fetch_pdf_tool(
+        &self,
+        args: JsonMap<String, Value>,
+    ) -> Result<CallToolResult> {
+        use skrills_tome::cache::ResearchCache;
+        use skrills_tome::clients::unpaywall::UnpaywallClient;
+
+        let doi = args
+            .get("doi")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing required parameter: doi"))?;
+
+        let unpaywall = UnpaywallClient::default();
+        let pdf_url = unpaywall
+            .find_pdf_url(doi)
+            .await?
+            .ok_or_else(|| anyhow!("No open-access PDF found for DOI: {doi}"))?;
+
+        let cache = ResearchCache::open()?;
+        let pdf_path = cache.pdf_dir().join(format!("{}.pdf", doi.replace('/', "_")));
+
+        // Download if not already cached
+        if !pdf_path.exists() {
+            let client = reqwest::Client::new();
+            let bytes = client.get(&pdf_url).send().await?.bytes().await?;
+            std::fs::write(&pdf_path, &bytes)?;
+        }
+
+        let path_str = pdf_path.to_string_lossy().to_string();
+
+        Ok(CallToolResult {
+            content: vec![Content::text(format!("PDF cached at: {path_str}"))],
+            structured_content: Some(json!({
+                "path": path_str,
+                "doi": doi,
+                "url": pdf_url,
+                "cached": true,
+            })),
+            is_error: Some(false),
+            meta: None,
+        })
+    }
+
+    // --- #169: Advanced Research Tools ---
+
+    pub(crate) fn query_knowledge_graph_tool(
+        &self,
+        args: JsonMap<String, Value>,
+    ) -> Result<CallToolResult> {
+        use skrills_tome::knowledge_graph::{KnowledgeGraph, NodeKind};
+
+        let db_path = tome_cache_dir()?.join("knowledge.db");
+        let kg = KnowledgeGraph::open(&db_path)?;
+
+        if let Some(node_id) = args.get("node_id").and_then(|v| v.as_str()) {
+            let direction = args
+                .get("direction")
+                .and_then(|v| v.as_str())
+                .unwrap_or("both");
+
+            let node = kg.get_node(node_id)?;
+            let mut edges_from = Vec::new();
+            let mut edges_to = Vec::new();
+
+            if direction == "from" || direction == "both" {
+                edges_from = kg.edges_from(node_id)?;
+            }
+            if direction == "to" || direction == "both" {
+                edges_to = kg.edges_to(node_id)?;
+            }
+
+            Ok(CallToolResult {
+                content: vec![Content::text(format!(
+                    "Node {}: {} outgoing, {} incoming edges",
+                    node_id,
+                    edges_from.len(),
+                    edges_to.len()
+                ))],
+                structured_content: Some(json!({
+                    "node": node.map(|n| json!({
+                        "id": n.id,
+                        "kind": n.kind.as_str(),
+                        "label": n.label,
+                    })),
+                    "edges_from": edges_from.iter().map(|e| json!({
+                        "target": e.target_id,
+                        "kind": e.kind.as_str(),
+                        "weight": e.weight,
+                    })).collect::<Vec<_>>(),
+                    "edges_to": edges_to.iter().map(|e| json!({
+                        "source": e.source_id,
+                        "kind": e.kind.as_str(),
+                        "weight": e.weight,
+                    })).collect::<Vec<_>>(),
+                })),
+                is_error: Some(false),
+                meta: None,
+            })
+        } else if let Some(query) = args.get("query").and_then(|v| v.as_str()) {
+            let kind = args
+                .get("kind")
+                .and_then(|v| v.as_str())
+                .and_then(|k| match k {
+                    "topic" => Some(NodeKind::Topic),
+                    "paper" => Some(NodeKind::Paper),
+                    "implementation" => Some(NodeKind::Implementation),
+                    "discussion" => Some(NodeKind::Discussion),
+                    _ => None,
+                });
+
+            let nodes = kg.search_nodes(query, kind)?;
+            let node_json: Vec<Value> = nodes
+                .iter()
+                .map(|n| {
+                    json!({
+                        "id": n.id,
+                        "kind": n.kind.as_str(),
+                        "label": n.label,
+                    })
+                })
+                .collect();
+
+            Ok(CallToolResult {
+                content: vec![Content::text(format!("Found {} nodes", nodes.len()))],
+                structured_content: Some(json!({ "nodes": node_json, "count": nodes.len() })),
+                is_error: Some(false),
+                meta: None,
+            })
+        } else {
+            let (node_count, edge_count) = kg.stats()?;
+            Ok(CallToolResult {
+                content: vec![Content::text(format!(
+                    "Knowledge graph: {} nodes, {} edges",
+                    node_count, edge_count
+                ))],
+                structured_content: Some(json!({
+                    "node_count": node_count,
+                    "edge_count": edge_count,
+                })),
+                is_error: Some(false),
+                meta: None,
+            })
+        }
+    }
+
+    pub(crate) fn add_knowledge_node_tool(
+        &self,
+        args: JsonMap<String, Value>,
+    ) -> Result<CallToolResult> {
+        use skrills_tome::knowledge_graph::{KnowledgeGraph, NodeKind};
+
+        let id = args
+            .get("id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing required parameter: id"))?;
+        let kind_str = args
+            .get("kind")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing required parameter: kind"))?;
+        let label = args
+            .get("label")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing required parameter: label"))?;
+        let metadata = args.get("metadata").map(|v| v.to_string());
+
+        let kind = match kind_str {
+            "topic" => NodeKind::Topic,
+            "paper" => NodeKind::Paper,
+            "implementation" => NodeKind::Implementation,
+            "discussion" => NodeKind::Discussion,
+            other => return Err(anyhow!("Unknown node kind: {other}")),
+        };
+
+        let db_path = tome_cache_dir()?.join("knowledge.db");
+        let kg = KnowledgeGraph::open(&db_path)?;
+        kg.add_node(id, kind, label, metadata.as_deref())?;
+
+        Ok(CallToolResult {
+            content: vec![Content::text(format!(
+                "Added node '{id}' ({kind_str}): {label}"
+            ))],
+            structured_content: Some(json!({"id": id, "kind": kind_str, "label": label})),
+            is_error: Some(false),
+            meta: None,
+        })
+    }
+
+    pub(crate) fn link_knowledge_tool(
+        &self,
+        args: JsonMap<String, Value>,
+    ) -> Result<CallToolResult> {
+        use skrills_tome::knowledge_graph::{EdgeKind, KnowledgeGraph};
+
+        let source_id = args
+            .get("source_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing required parameter: source_id"))?;
+        let target_id = args
+            .get("target_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing required parameter: target_id"))?;
+        let kind_str = args
+            .get("kind")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing required parameter: kind"))?;
+        let weight = args
+            .get("weight")
+            .and_then(|v| v.as_f64())
+            .unwrap_or(1.0);
+        let metadata = args.get("metadata").map(|v| v.to_string());
+
+        let kind = match kind_str {
+            "cites" => EdgeKind::Cites,
+            "implements" => EdgeKind::Implements,
+            "contradicts" => EdgeKind::Contradicts,
+            "extends" => EdgeKind::Extends,
+            "analogous_to" => EdgeKind::AnalogousTo,
+            other => return Err(anyhow!("Unknown edge kind: {other}")),
+        };
+
+        let db_path = tome_cache_dir()?.join("knowledge.db");
+        let kg = KnowledgeGraph::open(&db_path)?;
+        kg.add_edge(source_id, target_id, kind, weight, metadata.as_deref())?;
+
+        Ok(CallToolResult {
+            content: vec![Content::text(format!(
+                "Linked {source_id} --{kind_str}--> {target_id}"
+            ))],
+            structured_content: Some(json!({
+                "source_id": source_id,
+                "target_id": target_id,
+                "kind": kind_str,
+                "weight": weight,
+            })),
+            is_error: Some(false),
+            meta: None,
+        })
+    }
+
+    pub(crate) fn track_citations_tool(
+        &self,
+        args: JsonMap<String, Value>,
+    ) -> Result<CallToolResult> {
+        use skrills_tome::citations::CitationTracker;
+        use skrills_tome::models::{Paper, PaperSource};
+
+        let paper_id = args
+            .get("paper_id")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing required parameter: paper_id"))?;
+        let action = args
+            .get("action")
+            .and_then(|v| v.as_str())
+            .unwrap_or("track");
+
+        let db_path = tome_cache_dir()?.join("citations.db");
+        let tracker = CitationTracker::open(&db_path)?;
+
+        match action {
+            "track" => {
+                let title = args
+                    .get("title")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| {
+                        anyhow!("Missing required parameter: title (for track action)")
+                    })?;
+                let doi = args.get("doi").and_then(|v| v.as_str()).map(String::from);
+
+                let paper = Paper {
+                    id: paper_id.to_string(),
+                    title: title.to_string(),
+                    authors: Vec::new(),
+                    abstract_text: None,
+                    year: None,
+                    doi,
+                    url: None,
+                    source: PaperSource::CrossRef,
+                    citation_count: None,
+                    pdf_url: None,
+                };
+                tracker.track_paper(&paper)?;
+
+                Ok(CallToolResult {
+                    content: vec![Content::text(format!("Now tracking: {title}"))],
+                    structured_content: Some(
+                        json!({"paper_id": paper_id, "title": title, "action": "tracked"}),
+                    ),
+                    is_error: Some(false),
+                    meta: None,
+                })
+            }
+            "forward" => {
+                let citations = tracker.forward_citations(paper_id)?;
+                let citation_json: Vec<Value> = citations
+                    .iter()
+                    .map(|c| {
+                        json!({
+                            "citing_id": c.citing_paper_id,
+                            "cited_id": c.cited_paper_id,
+                            "context": c.context,
+                        })
+                    })
+                    .collect();
+
+                Ok(CallToolResult {
+                    content: vec![Content::text(format!(
+                        "{} forward citations",
+                        citations.len()
+                    ))],
+                    structured_content: Some(json!({
+                        "citations": citation_json,
+                        "count": citations.len(),
+                        "direction": "forward",
+                    })),
+                    is_error: Some(false),
+                    meta: None,
+                })
+            }
+            "backward" => {
+                let citations = tracker.backward_citations(paper_id)?;
+                let citation_json: Vec<Value> = citations
+                    .iter()
+                    .map(|c| {
+                        json!({
+                            "citing_id": c.citing_paper_id,
+                            "cited_id": c.cited_paper_id,
+                            "context": c.context,
+                        })
+                    })
+                    .collect();
+
+                Ok(CallToolResult {
+                    content: vec![Content::text(format!(
+                        "{} backward citations",
+                        citations.len()
+                    ))],
+                    structured_content: Some(json!({
+                        "citations": citation_json,
+                        "count": citations.len(),
+                        "direction": "backward",
+                    })),
+                    is_error: Some(false),
+                    meta: None,
+                })
+            }
+            other => Err(anyhow!(
+                "Unknown action: {other}. Use 'track', 'forward', or 'backward'"
+            )),
+        }
+    }
+
+    pub(crate) fn resolve_contradiction_tool(
+        &self,
+        args: JsonMap<String, Value>,
+    ) -> Result<CallToolResult> {
+        use skrills_tome::triz::TrizMatrix;
+
+        let improve_str = args
+            .get("improve")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing required parameter: improve"))?;
+        let degrades_str = args
+            .get("degrades")
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| anyhow!("Missing required parameter: degrades"))?;
+
+        let improve = parse_parameter(improve_str)?;
+        let degrades = parse_parameter(degrades_str)?;
+
+        let matrix = TrizMatrix::new();
+        let principles = matrix.resolve(improve, degrades);
+
+        let principle_json: Vec<Value> = principles
+            .iter()
+            .map(|p| {
+                json!({
+                    "number": p.number,
+                    "name": p.name,
+                    "description": p.description,
+                    "software_examples": p.software_examples,
+                })
+            })
+            .collect();
+
+        Ok(CallToolResult {
+            content: vec![Content::text(format!(
+                "Improving {} vs degrading {}: {} applicable principles",
+                improve_str,
+                degrades_str,
+                principles.len()
+            ))],
+            structured_content: Some(json!({
+                "improve": improve_str,
+                "degrades": degrades_str,
+                "principles": principle_json,
+                "count": principles.len(),
+            })),
+            is_error: Some(false),
+            meta: None,
+        })
+    }
+}
+
+fn parse_parameter(s: &str) -> Result<skrills_tome::triz::Parameter> {
+    use skrills_tome::triz::Parameter;
+    match s {
+        "performance" => Ok(Parameter::Performance),
+        "reliability" => Ok(Parameter::Reliability),
+        "maintainability" => Ok(Parameter::Maintainability),
+        "scalability" => Ok(Parameter::Scalability),
+        "security" => Ok(Parameter::Security),
+        "usability" => Ok(Parameter::Usability),
+        "testability" => Ok(Parameter::Testability),
+        "deployability" => Ok(Parameter::Deployability),
+        "cost_efficiency" => Ok(Parameter::CostEfficiency),
+        "development_speed" => Ok(Parameter::DevelopmentSpeed),
+        "code_complexity" => Ok(Parameter::CodeComplexity),
+        "memory_usage" => Ok(Parameter::MemoryUsage),
+        "latency" => Ok(Parameter::Latency),
+        "throughput" => Ok(Parameter::Throughput),
+        "availability" => Ok(Parameter::Availability),
+        other => Err(anyhow!("Unknown parameter: {other}")),
+    }
+}

--- a/crates/server/src/app/research.rs
+++ b/crates/server/src/app/research.rs
@@ -137,10 +137,7 @@ impl SkillService {
             .get("query")
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow!("Missing required parameter: query"))?;
-        let limit = args
-            .get("limit")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(10) as usize;
+        let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(10) as usize;
 
         let client = HnAlgoliaClient::new();
         let discussions = client.search(query, limit).await?;
@@ -235,7 +232,9 @@ impl SkillService {
             .ok_or_else(|| anyhow!("No open-access PDF found for DOI: {doi}"))?;
 
         let cache = ResearchCache::open()?;
-        let pdf_path = cache.pdf_dir().join(format!("{}.pdf", doi.replace('/', "_")));
+        let pdf_path = cache
+            .pdf_dir()
+            .join(format!("{}.pdf", doi.replace('/', "_")));
 
         // Download if not already cached
         if !pdf_path.exists() {
@@ -421,10 +420,7 @@ impl SkillService {
             .get("kind")
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow!("Missing required parameter: kind"))?;
-        let weight = args
-            .get("weight")
-            .and_then(|v| v.as_f64())
-            .unwrap_or(1.0);
+        let weight = args.get("weight").and_then(|v| v.as_f64()).unwrap_or(1.0);
         let metadata = args.get("metadata").map(|v| v.to_string());
 
         let kind = match kind_str {
@@ -476,12 +472,9 @@ impl SkillService {
 
         match action {
             "track" => {
-                let title = args
-                    .get("title")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| {
-                        anyhow!("Missing required parameter: title (for track action)")
-                    })?;
+                let title = args.get("title").and_then(|v| v.as_str()).ok_or_else(|| {
+                    anyhow!("Missing required parameter: title (for track action)")
+                })?;
                 let doi = args.get("doi").and_then(|v| v.as_str()).map(String::from);
 
                 let paper = Paper {

--- a/crates/server/src/app/tests/mod.rs
+++ b/crates/server/src/app/tests/mod.rs
@@ -11,11 +11,13 @@
 //! - `intelligence` - Smart recommendations, skill creation, GitHub search
 //! - `mcp` - MCP registry, tool operations, context stats
 //! - `sync` - Sync error paths and parameter handling
+//! - `research` - Knowledge graph, citation tracking, TRIZ resolution
 
 mod config;
 mod dependency;
 mod intelligence;
 mod mcp;
+mod research;
 mod resource;
 mod search;
 mod sync;

--- a/crates/server/src/app/tests/research.rs
+++ b/crates/server/src/app/tests/research.rs
@@ -1,0 +1,618 @@
+//! Research tool tests - Knowledge graph, citation tracking, TRIZ resolution
+//!
+//! Tests the 5 sync research tool handlers that operate on local databases,
+//! plus parameter validation for all 9 tools.
+
+use super::super::*;
+use serde_json::json;
+use std::time::Duration;
+
+// -------------------------------------------------------------------------
+// resolve_contradiction_tool Tests
+// -------------------------------------------------------------------------
+
+/// GIVEN valid TRIZ parameters
+/// WHEN resolve_contradiction_tool is called
+/// THEN it returns applicable principles
+#[test]
+fn resolve_contradiction_returns_principles() {
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    let args = json!({
+        "improve": "performance",
+        "degrades": "reliability"
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+
+    let result = service.resolve_contradiction_tool(args).unwrap();
+    assert!(!result.is_error.unwrap_or(true));
+
+    let structured = result.structured_content.unwrap();
+    let principles = structured
+        .get("principles")
+        .and_then(|v| v.as_array())
+        .unwrap();
+    assert!(
+        !principles.is_empty(),
+        "Should return at least one principle"
+    );
+
+    // Each principle should have number, name, description
+    let first = &principles[0];
+    assert!(first.get("number").is_some());
+    assert!(first.get("name").is_some());
+    assert!(first.get("description").is_some());
+}
+
+/// GIVEN an unknown TRIZ parameter
+/// WHEN resolve_contradiction_tool is called
+/// THEN it returns an error
+#[test]
+fn resolve_contradiction_rejects_unknown_parameter() {
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    let args = json!({
+        "improve": "speed_of_light",
+        "degrades": "reliability"
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+
+    let result = service.resolve_contradiction_tool(args);
+    assert!(result.is_err());
+    assert!(
+        result
+            .unwrap_err()
+            .to_string()
+            .contains("Unknown parameter"),
+        "Should mention unknown parameter"
+    );
+}
+
+/// GIVEN missing required parameters
+/// WHEN resolve_contradiction_tool is called
+/// THEN it returns an error for each missing param
+#[test]
+fn resolve_contradiction_requires_both_params() {
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    // Missing 'degrades'
+    let args = json!({"improve": "performance"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    let err = service.resolve_contradiction_tool(args).unwrap_err();
+    assert!(err.to_string().contains("degrades"));
+
+    // Missing 'improve'
+    let args = json!({"degrades": "reliability"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    let err = service.resolve_contradiction_tool(args).unwrap_err();
+    assert!(err.to_string().contains("improve"));
+}
+
+/// GIVEN all 15 valid TRIZ parameters
+/// WHEN each is used as 'improve'
+/// THEN parsing succeeds (no error)
+#[test]
+fn resolve_contradiction_accepts_all_parameters() {
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    let all_params = [
+        "performance",
+        "reliability",
+        "maintainability",
+        "scalability",
+        "security",
+        "usability",
+        "testability",
+        "deployability",
+        "cost_efficiency",
+        "development_speed",
+        "code_complexity",
+        "memory_usage",
+        "latency",
+        "throughput",
+        "availability",
+    ];
+
+    for param in all_params {
+        let args = json!({
+            "improve": param,
+            "degrades": "reliability"
+        })
+        .as_object()
+        .cloned()
+        .unwrap();
+
+        let result = service.resolve_contradiction_tool(args);
+        assert!(
+            result.is_ok(),
+            "Parameter '{}' should be accepted, got: {:?}",
+            param,
+            result.err()
+        );
+    }
+}
+
+// -------------------------------------------------------------------------
+// Knowledge Graph Tool Tests
+// -------------------------------------------------------------------------
+
+/// GIVEN a fresh knowledge graph database
+/// WHEN add_knowledge_node_tool is called with valid args
+/// THEN the node is created and can be queried
+#[test]
+fn add_and_query_knowledge_node() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    // Add a node
+    let args = json!({
+        "id": "topic-rust-async",
+        "kind": "topic",
+        "label": "Rust Async Programming"
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+
+    let result = service.add_knowledge_node_tool(args).unwrap();
+    assert!(!result.is_error.unwrap_or(true));
+
+    let structured = result.structured_content.unwrap();
+    assert_eq!(structured.get("id").unwrap(), "topic-rust-async");
+    assert_eq!(structured.get("kind").unwrap(), "topic");
+
+    // Query the node by ID
+    let args = json!({"node_id": "topic-rust-async"})
+        .as_object()
+        .cloned()
+        .unwrap();
+
+    let result = service.query_knowledge_graph_tool(args).unwrap();
+    assert!(!result.is_error.unwrap_or(true));
+
+    let structured = result.structured_content.unwrap();
+    let node = structured.get("node").unwrap();
+    assert_eq!(node.get("label").unwrap(), "Rust Async Programming");
+}
+
+/// GIVEN missing required parameters
+/// WHEN add_knowledge_node_tool is called
+/// THEN it returns appropriate errors
+#[test]
+fn add_knowledge_node_requires_params() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    // Missing 'id'
+    let args = json!({"kind": "topic", "label": "test"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    let err = service.add_knowledge_node_tool(args).unwrap_err();
+    assert!(err.to_string().contains("id"));
+
+    // Missing 'kind'
+    let args = json!({"id": "test", "label": "test"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    let err = service.add_knowledge_node_tool(args).unwrap_err();
+    assert!(err.to_string().contains("kind"));
+
+    // Missing 'label'
+    let args = json!({"id": "test", "kind": "topic"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    let err = service.add_knowledge_node_tool(args).unwrap_err();
+    assert!(err.to_string().contains("label"));
+}
+
+/// GIVEN an unknown node kind
+/// WHEN add_knowledge_node_tool is called
+/// THEN it returns an error
+#[test]
+fn add_knowledge_node_rejects_unknown_kind() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    let args = json!({
+        "id": "test-node",
+        "kind": "banana",
+        "label": "Invalid kind"
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+
+    let err = service.add_knowledge_node_tool(args).unwrap_err();
+    assert!(err.to_string().contains("Unknown node kind"));
+}
+
+/// GIVEN an empty knowledge graph
+/// WHEN query_knowledge_graph_tool is called with no args
+/// THEN it returns stats with zero counts
+#[test]
+fn query_knowledge_graph_returns_stats() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    let args = json!({}).as_object().cloned().unwrap();
+    let result = service.query_knowledge_graph_tool(args).unwrap();
+    assert!(!result.is_error.unwrap_or(true));
+
+    let structured = result.structured_content.unwrap();
+    assert_eq!(structured.get("node_count").unwrap(), 0);
+    assert_eq!(structured.get("edge_count").unwrap(), 0);
+}
+
+// -------------------------------------------------------------------------
+// link_knowledge_tool Tests
+// -------------------------------------------------------------------------
+
+/// GIVEN two nodes in the knowledge graph
+/// WHEN link_knowledge_tool is called
+/// THEN an edge is created between them
+#[test]
+fn link_knowledge_creates_edge() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    // Add two nodes first
+    let add = |id: &str, kind: &str, label: &str| {
+        let args = json!({"id": id, "kind": kind, "label": label})
+            .as_object()
+            .cloned()
+            .unwrap();
+        service.add_knowledge_node_tool(args).unwrap();
+    };
+    add("paper-1", "paper", "Async Rust Survey");
+    add("topic-async", "topic", "Async Programming");
+
+    // Link them
+    let args = json!({
+        "source_id": "paper-1",
+        "target_id": "topic-async",
+        "kind": "implements",
+        "weight": 0.9
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+
+    let result = service.link_knowledge_tool(args).unwrap();
+    assert!(!result.is_error.unwrap_or(true));
+
+    let structured = result.structured_content.unwrap();
+    assert_eq!(structured.get("source_id").unwrap(), "paper-1");
+    assert_eq!(structured.get("target_id").unwrap(), "topic-async");
+    assert_eq!(structured.get("kind").unwrap(), "implements");
+
+    // Verify edge exists via query
+    let args = json!({"node_id": "paper-1", "direction": "from"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    let result = service.query_knowledge_graph_tool(args).unwrap();
+    let structured = result.structured_content.unwrap();
+    let edges = structured.get("edges_from").unwrap().as_array().unwrap();
+    assert_eq!(edges.len(), 1);
+    assert_eq!(edges[0].get("target").unwrap(), "topic-async");
+}
+
+/// GIVEN missing required parameters
+/// WHEN link_knowledge_tool is called
+/// THEN it returns errors
+#[test]
+fn link_knowledge_requires_params() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    // Missing source_id
+    let args = json!({"target_id": "t", "kind": "cites"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    assert!(service
+        .link_knowledge_tool(args)
+        .unwrap_err()
+        .to_string()
+        .contains("source_id"));
+
+    // Missing target_id
+    let args = json!({"source_id": "s", "kind": "cites"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    assert!(service
+        .link_knowledge_tool(args)
+        .unwrap_err()
+        .to_string()
+        .contains("target_id"));
+
+    // Missing kind
+    let args = json!({"source_id": "s", "target_id": "t"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    assert!(service
+        .link_knowledge_tool(args)
+        .unwrap_err()
+        .to_string()
+        .contains("kind"));
+}
+
+/// GIVEN an unknown edge kind
+/// WHEN link_knowledge_tool is called
+/// THEN it returns an error
+#[test]
+fn link_knowledge_rejects_unknown_edge_kind() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    let args = json!({
+        "source_id": "a",
+        "target_id": "b",
+        "kind": "banana"
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+
+    let err = service.link_knowledge_tool(args).unwrap_err();
+    assert!(err.to_string().contains("Unknown edge kind"));
+}
+
+// -------------------------------------------------------------------------
+// track_citations_tool Tests
+// -------------------------------------------------------------------------
+
+/// GIVEN a fresh citation database
+/// WHEN track_citations_tool is called with action=track
+/// THEN the paper is tracked
+#[test]
+fn track_citations_tracks_paper() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    let args = json!({
+        "paper_id": "paper-001",
+        "action": "track",
+        "title": "Async Rust Patterns",
+        "doi": "10.1234/async-rust"
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+
+    let result = service.track_citations_tool(args).unwrap();
+    assert!(!result.is_error.unwrap_or(true));
+
+    let structured = result.structured_content.unwrap();
+    assert_eq!(structured.get("action").unwrap(), "tracked");
+    assert_eq!(structured.get("paper_id").unwrap(), "paper-001");
+}
+
+/// GIVEN a tracked paper with no citations
+/// WHEN track_citations_tool is called with action=forward
+/// THEN it returns an empty citations list
+#[test]
+fn track_citations_forward_empty() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    // Track a paper first
+    let args = json!({
+        "paper_id": "paper-002",
+        "action": "track",
+        "title": "Test Paper"
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+    service.track_citations_tool(args).unwrap();
+
+    // Query forward citations
+    let args = json!({
+        "paper_id": "paper-002",
+        "action": "forward"
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+
+    let result = service.track_citations_tool(args).unwrap();
+    assert!(!result.is_error.unwrap_or(true));
+
+    let structured = result.structured_content.unwrap();
+    assert_eq!(structured.get("count").unwrap(), 0);
+    assert_eq!(structured.get("direction").unwrap(), "forward");
+}
+
+/// GIVEN missing required parameters
+/// WHEN track_citations_tool is called
+/// THEN it returns errors
+#[test]
+fn track_citations_requires_paper_id() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    let args = json!({"action": "track", "title": "No ID"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    let err = service.track_citations_tool(args).unwrap_err();
+    assert!(err.to_string().contains("paper_id"));
+}
+
+/// GIVEN a track action without title
+/// WHEN track_citations_tool is called
+/// THEN it returns an error about missing title
+#[test]
+fn track_citations_track_requires_title() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    let args = json!({
+        "paper_id": "paper-003",
+        "action": "track"
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+
+    let err = service.track_citations_tool(args).unwrap_err();
+    assert!(err.to_string().contains("title"));
+}
+
+/// GIVEN an unknown action
+/// WHEN track_citations_tool is called
+/// THEN it returns an error
+#[test]
+fn track_citations_rejects_unknown_action() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    let args = json!({
+        "paper_id": "paper-004",
+        "action": "explode"
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+
+    let err = service.track_citations_tool(args).unwrap_err();
+    assert!(err.to_string().contains("Unknown action"));
+}
+
+// -------------------------------------------------------------------------
+// Tool Schema Tests
+// -------------------------------------------------------------------------
+
+/// GIVEN the research tool schemas
+/// WHEN inspecting required fields
+/// THEN each tool has correct required parameters
+#[test]
+fn research_tool_schemas_have_correct_required_fields() {
+    use crate::tool_schemas::research_tools;
+
+    let tools = research_tools();
+    let tool_map: std::collections::HashMap<&str, &rmcp::model::Tool> =
+        tools.iter().map(|t| (t.name.as_ref(), t)).collect();
+
+    // search-papers requires "query"
+    let schema = tool_map["search-papers"].input_schema.as_ref();
+    let required = schema.get("required").unwrap().as_array().unwrap();
+    assert!(required.contains(&json!("query")));
+
+    // search-discussions requires "query"
+    let schema = tool_map["search-discussions"].input_schema.as_ref();
+    let required = schema.get("required").unwrap().as_array().unwrap();
+    assert!(required.contains(&json!("query")));
+
+    // resolve-doi requires "doi"
+    let schema = tool_map["resolve-doi"].input_schema.as_ref();
+    let required = schema.get("required").unwrap().as_array().unwrap();
+    assert!(required.contains(&json!("doi")));
+
+    // fetch-pdf requires "doi"
+    let schema = tool_map["fetch-pdf"].input_schema.as_ref();
+    let required = schema.get("required").unwrap().as_array().unwrap();
+    assert!(required.contains(&json!("doi")));
+
+    // add-knowledge-node requires "id", "kind", "label"
+    let schema = tool_map["add-knowledge-node"].input_schema.as_ref();
+    let required = schema.get("required").unwrap().as_array().unwrap();
+    assert!(required.contains(&json!("id")));
+    assert!(required.contains(&json!("kind")));
+    assert!(required.contains(&json!("label")));
+
+    // link-knowledge requires "source_id", "target_id", "kind"
+    let schema = tool_map["link-knowledge"].input_schema.as_ref();
+    let required = schema.get("required").unwrap().as_array().unwrap();
+    assert!(required.contains(&json!("source_id")));
+    assert!(required.contains(&json!("target_id")));
+    assert!(required.contains(&json!("kind")));
+
+    // resolve-contradiction requires "improve", "degrades"
+    let schema = tool_map["resolve-contradiction"].input_schema.as_ref();
+    let required = schema.get("required").unwrap().as_array().unwrap();
+    assert!(required.contains(&json!("improve")));
+    assert!(required.contains(&json!("degrades")));
+}
+
+/// GIVEN the research tool schemas
+/// WHEN checking tool names
+/// THEN all 9 expected tools are present
+#[test]
+fn research_tools_has_all_expected_names() {
+    use crate::tool_schemas::research_tools;
+
+    let tools = research_tools();
+    let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
+
+    let expected = [
+        "search-papers",
+        "search-discussions",
+        "resolve-doi",
+        "fetch-pdf",
+        "query-knowledge-graph",
+        "add-knowledge-node",
+        "link-knowledge",
+        "track-citations",
+        "resolve-contradiction",
+    ];
+
+    for name in expected {
+        assert!(
+            names.contains(&name),
+            "Expected tool '{}' in research_tools, found: {:?}",
+            name,
+            names
+        );
+    }
+}

--- a/crates/server/src/app/tests/sync.rs
+++ b/crates/server/src/app/tests/sync.rs
@@ -75,3 +75,26 @@ fn sync_skills_tool_explicit_to_overrides_default() {
         "Error should mention 'cannot be the same', got: {msg}"
     );
 }
+
+/// Default sync target is applied when no explicit `to` is provided.
+///
+/// Given: from = "claude", no `to` parameter
+/// When: sync_skills_tool is called
+/// Then: The default target "codex" is used (no same-source error)
+#[test]
+fn sync_skills_tool_uses_default_target_when_to_omitted() {
+    let service =
+        SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).expect("create service");
+    let mut args = serde_json::Map::new();
+    args.insert("from".into(), serde_json::json!("claude"));
+    args.insert("dry_run".into(), serde_json::json!(true));
+    // No "to" parameter — should default to "codex" per default_target_for("claude")
+
+    let result = service.sync_skills_tool(args);
+    // Should NOT error with "cannot be the same" since default target differs from source
+    assert!(
+        result.is_ok(),
+        "Expected success when using default target, got: {:?}",
+        result.err()
+    );
+}

--- a/crates/server/src/handler.rs
+++ b/crates/server/src/handler.rs
@@ -188,6 +188,23 @@ impl ServerHandler for SkillService {
                     let args = request.arguments.clone().unwrap_or_default();
                     self.search_skills_github_tool(args).await
                 }
+                // Research tools (async — require HTTP calls to external APIs)
+                "search-papers" => {
+                    let args = request.arguments.clone().unwrap_or_default();
+                    self.search_papers_tool(args).await
+                }
+                "search-discussions" => {
+                    let args = request.arguments.clone().unwrap_or_default();
+                    self.search_discussions_tool(args).await
+                }
+                "resolve-doi" => {
+                    let args = request.arguments.clone().unwrap_or_default();
+                    self.resolve_doi_tool(args).await
+                }
+                "fetch-pdf" => {
+                    let args = request.arguments.clone().unwrap_or_default();
+                    self.fetch_pdf_tool(args).await
+                }
                 _ => (|| -> Result<CallToolResult> {
                     match request.name.as_ref() {
                     "sync-from-claude" => {
@@ -714,6 +731,27 @@ impl ServerHandler for SkillService {
                         // Return current context stats from the real tracker
                         let stats = self.context_stats.snapshot();
                         crate::mcp_gateway::get_context_stats(stats)
+                    }
+                    // Research tools (sync — local database operations)
+                    "query-knowledge-graph" => {
+                        let args = request.arguments.clone().unwrap_or_default();
+                        self.query_knowledge_graph_tool(args)
+                    }
+                    "add-knowledge-node" => {
+                        let args = request.arguments.clone().unwrap_or_default();
+                        self.add_knowledge_node_tool(args)
+                    }
+                    "link-knowledge" => {
+                        let args = request.arguments.clone().unwrap_or_default();
+                        self.link_knowledge_tool(args)
+                    }
+                    "track-citations" => {
+                        let args = request.arguments.clone().unwrap_or_default();
+                        self.track_citations_tool(args)
+                    }
+                    "resolve-contradiction" => {
+                        let args = request.arguments.clone().unwrap_or_default();
+                        self.resolve_contradiction_tool(args)
                     }
                     other => Err(anyhow!("unknown tool {other}")),
                 }

--- a/crates/server/src/tool_schemas.rs
+++ b/crates/server/src/tool_schemas.rs
@@ -826,6 +826,354 @@ pub(crate) fn intelligence_tools() -> Vec<Tool> {
     ]
 }
 
+/// Returns research tools for academic paper search, knowledge graphs, and TRIZ.
+///
+/// Tools: search-papers, search-discussions, resolve-doi, fetch-pdf,
+/// query-knowledge-graph, add-knowledge-node, link-knowledge, track-citations,
+/// resolve-contradiction
+pub(crate) fn research_tools() -> Vec<Tool> {
+    vec![
+        // --- #168 Tools (Research API) ---
+        Tool {
+            name: "search-papers".into(),
+            title: Some("Search academic papers".into()),
+            description: Some(
+                "Search for academic papers across Semantic Scholar, arXiv, and OpenAlex. Deduplicates results by DOI.".into(),
+            ),
+            input_schema: Arc::new({
+                let mut schema = JsonMap::new();
+                schema.insert("type".into(), json!("object"));
+                schema.insert(
+                    "properties".into(),
+                    json!({
+                        "query": {
+                            "type": "string",
+                            "description": "Search query for academic papers"
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "default": 10,
+                            "maximum": 100,
+                            "description": "Maximum number of results to return (default 10, max 100)"
+                        },
+                        "sources": {
+                            "type": "array",
+                            "items": {
+                                "type": "string",
+                                "enum": ["arxiv", "semantic_scholar", "openalex"]
+                            },
+                            "description": "Paper sources to search (defaults to all)"
+                        }
+                    }),
+                );
+                schema.insert("required".into(), json!(["query"]));
+                schema.insert("additionalProperties".into(), json!(false));
+                schema
+            }),
+            output_schema: None,
+            annotations: Some(ToolAnnotations::default()),
+            icons: None,
+            meta: None,
+        },
+        Tool {
+            name: "search-discussions".into(),
+            title: Some("Search community discussions".into()),
+            description: Some(
+                "Search Hacker News for community discussions about a topic.".into(),
+            ),
+            input_schema: Arc::new({
+                let mut schema = JsonMap::new();
+                schema.insert("type".into(), json!("object"));
+                schema.insert(
+                    "properties".into(),
+                    json!({
+                        "query": {
+                            "type": "string",
+                            "description": "Search query for discussions"
+                        },
+                        "limit": {
+                            "type": "integer",
+                            "default": 10,
+                            "description": "Maximum number of results to return"
+                        }
+                    }),
+                );
+                schema.insert("required".into(), json!(["query"]));
+                schema.insert("additionalProperties".into(), json!(false));
+                schema
+            }),
+            output_schema: None,
+            annotations: Some(ToolAnnotations::default()),
+            icons: None,
+            meta: None,
+        },
+        Tool {
+            name: "resolve-doi".into(),
+            title: Some("Resolve DOI metadata".into()),
+            description: Some(
+                "Resolve a DOI to full metadata via CrossRef, with open-access PDF URL from Unpaywall.".into(),
+            ),
+            input_schema: Arc::new({
+                let mut schema = JsonMap::new();
+                schema.insert("type".into(), json!("object"));
+                schema.insert(
+                    "properties".into(),
+                    json!({
+                        "doi": {
+                            "type": "string",
+                            "description": "DOI to resolve (e.g., '10.1234/example')"
+                        }
+                    }),
+                );
+                schema.insert("required".into(), json!(["doi"]));
+                schema.insert("additionalProperties".into(), json!(false));
+                schema
+            }),
+            output_schema: None,
+            annotations: Some(ToolAnnotations::default()),
+            icons: None,
+            meta: None,
+        },
+        Tool {
+            name: "fetch-pdf".into(),
+            title: Some("Download and cache academic PDF".into()),
+            description: Some(
+                "Download the open-access PDF for a DOI via Unpaywall and cache it locally. Returns the local file path.".into(),
+            ),
+            input_schema: Arc::new({
+                let mut schema = JsonMap::new();
+                schema.insert("type".into(), json!("object"));
+                schema.insert(
+                    "properties".into(),
+                    json!({
+                        "doi": {
+                            "type": "string",
+                            "description": "DOI of the paper to fetch PDF for"
+                        }
+                    }),
+                );
+                schema.insert("required".into(), json!(["doi"]));
+                schema.insert("additionalProperties".into(), json!(false));
+                schema
+            }),
+            output_schema: None,
+            annotations: Some(ToolAnnotations::default()),
+            icons: None,
+            meta: None,
+        },
+        // --- #169 Tools (Advanced Features) ---
+        Tool {
+            name: "query-knowledge-graph".into(),
+            title: Some("Search and traverse knowledge graph".into()),
+            description: Some(
+                "Search nodes or traverse edges in the research knowledge graph. Provide query to search, or node_id to get connections.".into(),
+            ),
+            input_schema: Arc::new({
+                let mut schema = JsonMap::new();
+                schema.insert("type".into(), json!("object"));
+                schema.insert(
+                    "properties".into(),
+                    json!({
+                        "query": {
+                            "type": "string",
+                            "description": "Text query to search nodes"
+                        },
+                        "node_id": {
+                            "type": "string",
+                            "description": "Node ID to get connections for"
+                        },
+                        "direction": {
+                            "type": "string",
+                            "enum": ["from", "to", "both"],
+                            "description": "Edge traversal direction when using node_id"
+                        },
+                        "kind": {
+                            "type": "string",
+                            "enum": ["topic", "paper", "implementation", "discussion"],
+                            "description": "Filter by node kind"
+                        }
+                    }),
+                );
+                schema.insert("additionalProperties".into(), json!(false));
+                schema
+            }),
+            output_schema: None,
+            annotations: Some(ToolAnnotations::default()),
+            icons: None,
+            meta: None,
+        },
+        Tool {
+            name: "add-knowledge-node".into(),
+            title: Some("Add a node to the knowledge graph".into()),
+            description: Some(
+                "Add a node to the persistent research knowledge graph.".into(),
+            ),
+            input_schema: Arc::new({
+                let mut schema = JsonMap::new();
+                schema.insert("type".into(), json!("object"));
+                schema.insert(
+                    "properties".into(),
+                    json!({
+                        "id": {
+                            "type": "string",
+                            "description": "Unique node identifier"
+                        },
+                        "kind": {
+                            "type": "string",
+                            "enum": ["topic", "paper", "implementation", "discussion"],
+                            "description": "Node kind"
+                        },
+                        "label": {
+                            "type": "string",
+                            "description": "Human-readable node label"
+                        },
+                        "metadata": {
+                            "type": "object",
+                            "description": "Optional metadata for the node"
+                        }
+                    }),
+                );
+                schema.insert("required".into(), json!(["id", "kind", "label"]));
+                schema.insert("additionalProperties".into(), json!(false));
+                schema
+            }),
+            output_schema: None,
+            annotations: Some(ToolAnnotations::default()),
+            icons: None,
+            meta: None,
+        },
+        Tool {
+            name: "link-knowledge".into(),
+            title: Some("Connect nodes in the knowledge graph".into()),
+            description: Some(
+                "Create a directed edge between two nodes in the knowledge graph.".into(),
+            ),
+            input_schema: Arc::new({
+                let mut schema = JsonMap::new();
+                schema.insert("type".into(), json!("object"));
+                schema.insert(
+                    "properties".into(),
+                    json!({
+                        "source_id": {
+                            "type": "string",
+                            "description": "Source node ID"
+                        },
+                        "target_id": {
+                            "type": "string",
+                            "description": "Target node ID"
+                        },
+                        "kind": {
+                            "type": "string",
+                            "enum": ["cites", "implements", "contradicts", "extends", "analogous_to"],
+                            "description": "Edge relationship kind"
+                        },
+                        "weight": {
+                            "type": "number",
+                            "default": 1.0,
+                            "description": "Edge weight (default 1.0)"
+                        },
+                        "metadata": {
+                            "type": "object",
+                            "description": "Optional metadata for the edge"
+                        }
+                    }),
+                );
+                schema.insert("required".into(), json!(["source_id", "target_id", "kind"]));
+                schema.insert("additionalProperties".into(), json!(false));
+                schema
+            }),
+            output_schema: None,
+            annotations: Some(ToolAnnotations::default()),
+            icons: None,
+            meta: None,
+        },
+        Tool {
+            name: "track-citations".into(),
+            title: Some("Track paper citations".into()),
+            description: Some(
+                "Track a paper for citation monitoring, or query forward/backward citations.".into(),
+            ),
+            input_schema: Arc::new({
+                let mut schema = JsonMap::new();
+                schema.insert("type".into(), json!("object"));
+                schema.insert(
+                    "properties".into(),
+                    json!({
+                        "paper_id": {
+                            "type": "string",
+                            "description": "Paper identifier (e.g., Semantic Scholar ID)"
+                        },
+                        "title": {
+                            "type": "string",
+                            "description": "Paper title for display"
+                        },
+                        "doi": {
+                            "type": "string",
+                            "description": "Optional DOI for cross-referencing"
+                        },
+                        "action": {
+                            "type": "string",
+                            "enum": ["track", "forward", "backward"],
+                            "default": "track",
+                            "description": "Action: 'track' to monitor, 'forward' for citing papers, 'backward' for referenced papers"
+                        }
+                    }),
+                );
+                schema.insert("required".into(), json!(["paper_id", "title"]));
+                schema.insert("additionalProperties".into(), json!(false));
+                schema
+            }),
+            output_schema: None,
+            annotations: Some(ToolAnnotations::default()),
+            icons: None,
+            meta: None,
+        },
+        Tool {
+            name: "resolve-contradiction".into(),
+            title: Some("TRIZ contradiction resolution".into()),
+            description: Some(
+                "Apply TRIZ inventive principles to resolve a contradiction between two parameters. Returns applicable principles with software examples.".into(),
+            ),
+            input_schema: Arc::new({
+                let mut schema = JsonMap::new();
+                schema.insert("type".into(), json!("object"));
+                schema.insert(
+                    "properties".into(),
+                    json!({
+                        "improve": {
+                            "type": "string",
+                            "enum": [
+                                "performance", "reliability", "maintainability", "scalability",
+                                "security", "usability", "testability", "deployability",
+                                "cost_efficiency", "development_speed", "code_complexity",
+                                "memory_usage", "latency", "throughput", "availability"
+                            ],
+                            "description": "Parameter to improve"
+                        },
+                        "degrades": {
+                            "type": "string",
+                            "enum": [
+                                "performance", "reliability", "maintainability", "scalability",
+                                "security", "usability", "testability", "deployability",
+                                "cost_efficiency", "development_speed", "code_complexity",
+                                "memory_usage", "latency", "throughput", "availability"
+                            ],
+                            "description": "Parameter that would degrade"
+                        }
+                    }),
+                );
+                schema.insert("required".into(), json!(["improve", "degrades"]));
+                schema.insert("additionalProperties".into(), json!(false));
+                schema
+            }),
+            output_schema: None,
+            annotations: Some(ToolAnnotations::default()),
+            icons: None,
+            meta: None,
+        },
+    ]
+}
+
 /// Returns all MCP tools.
 ///
 /// This combines all tool groups and is used by the `list_tools()` handler.
@@ -838,6 +1186,7 @@ pub(crate) fn all_tools() -> Vec<Tool> {
     tools.extend(metrics_tools());
     tools.extend(trace_tools());
     tools.extend(intelligence_tools());
+    tools.extend(research_tools());
     tools
 }
 
@@ -848,8 +1197,13 @@ mod tests {
     #[test]
     fn test_all_tools_returns_expected_count() {
         let tools = all_tools();
-        // 11 sync + 3 validation + 1 dependency + 1 recommend + 1 metrics + 4 trace + 6 intelligence = 27 tools
-        assert_eq!(tools.len(), 27);
+        // 11 sync + 3 validation + 1 dependency + 1 recommend + 1 metrics + 4 trace + 6 intelligence + 9 research = 36 tools
+        assert_eq!(tools.len(), 36);
+    }
+
+    #[test]
+    fn test_research_tools_count() {
+        assert_eq!(research_tools().len(), 9);
     }
 
     #[test]

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-state"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 description = "State management for skrills runtime options, pins, and persisted overrides."
 license = "MIT"

--- a/crates/subagents/Cargo.toml
+++ b/crates/subagents/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-subagents"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 description = "Subagent MCP tools for the skrills server with pluggable backends."
 license = "MIT"
@@ -28,8 +28,8 @@ thiserror.workspace = true
 tempfile.workspace = true
 toml.workspace = true
 
-skrills-discovery = { path = "../discovery", version = "0.7.3" }
-skrills-state = { path = "../state", version = "0.7.3" }
+skrills-discovery = { path = "../discovery", version = "0.7.4" }
+skrills-state = { path = "../state", version = "0.7.4" }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/crates/sync/Cargo.toml
+++ b/crates/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills_sync"
-version = "0.7.3"
+version = "0.7.4"
 edition.workspace = true
 description = "Preference synchronization and validation sync utilities for skrills"
 license = "MIT"
@@ -20,7 +20,7 @@ sha2.workspace = true
 walkdir.workspace = true
 dirs.workspace = true
 tracing.workspace = true
-skrills-validate = { path = "../validate", version = "0.7.3" }
+skrills-validate = { path = "../validate", version = "0.7.4" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/sync/src/adapters/cursor/utils.rs
+++ b/crates/sync/src/adapters/cursor/utils.rs
@@ -227,24 +227,6 @@ mod tests {
     }
 
     #[test]
-    fn split_frontmatter_crlf_line_endings() {
-        let content = "---\r\nname: test\r\n---\r\n\r\n# Body\r\n";
-        let (raw, body) = split_frontmatter(content);
-        assert!(raw.is_some(), "Should find frontmatter with CRLF endings");
-        let fm = raw.unwrap();
-        assert!(
-            fm.contains("name: test"),
-            "Frontmatter should contain 'name: test', got: {:?}",
-            fm
-        );
-        assert!(
-            body.starts_with("# Body"),
-            "Body should start with '# Body', got: {:?}",
-            body
-        );
-    }
-
-    #[test]
     fn sanitize_name_converts_to_kebab() {
         assert_eq!(sanitize_name("My Skill Name"), "my-skill-name");
         assert_eq!(

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills_test_utils"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 license = "Apache-2.0"
 description = "Shared test utilities for skrills crates"

--- a/crates/tome/Cargo.toml
+++ b/crates/tome/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-tome"
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 description = "Research API orchestration, caching, and knowledge graph for skrills."
 license = "MIT"

--- a/crates/tome/src/citations.rs
+++ b/crates/tome/src/citations.rs
@@ -38,6 +38,9 @@ impl CitationTracker {
         Ok(ct)
     }
 
+    // NOTE: CREATE TABLE IF NOT EXISTS means FK constraints only apply to new
+    // databases. Pre-existing databases keep the old schema without FKs.
+    // Acceptable pre-1.0; a migration step should be added before 1.0 release.
     fn init_schema(&self) -> TomeResult<()> {
         let conn = self.conn.lock().unwrap_or_else(|p| p.into_inner());
         conn.execute_batch(

--- a/crates/tome/src/clients/arxiv.rs
+++ b/crates/tome/src/clients/arxiv.rs
@@ -61,6 +61,7 @@ impl ArxivClient {
 /// Minimal Atom XML parser for arXiv results (no XML crate dependency).
 fn parse_arxiv_atom(xml: &str) -> Vec<Paper> {
     let mut papers = Vec::new();
+    let mut skipped = 0u32;
 
     for entry in xml.split("<entry>").skip(1) {
         let title = extract_tag(entry, "title").map(|t| t.replace('\n', " ").trim().to_string());
@@ -70,8 +71,6 @@ fn parse_arxiv_atom(xml: &str) -> Vec<Paper> {
 
         if let (Some(title), Some(id)) = (title, id) {
             let year = published.and_then(|p| p.get(..4).and_then(|y| y.parse().ok()));
-
-            // Extract arXiv ID from URL
             let arxiv_id = id.rsplit('/').next().unwrap_or(&id).to_string();
 
             papers.push(Paper {
@@ -86,7 +85,13 @@ fn parse_arxiv_atom(xml: &str) -> Vec<Paper> {
                 citation_count: None,
                 pdf_url: Some(format!("https://arxiv.org/pdf/{arxiv_id}")),
             });
+        } else {
+            skipped += 1;
         }
+    }
+
+    if skipped > 0 {
+        tracing::debug!(count = skipped, "skipped arXiv entries missing id or title");
     }
 
     papers

--- a/crates/tome/src/clients/hn_algolia.rs
+++ b/crates/tome/src/clients/hn_algolia.rs
@@ -22,7 +22,10 @@ impl HnAlgoliaClient {
             http: reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(30))
                 .build()
-                .unwrap_or_else(|_| reqwest::Client::new()),
+                .unwrap_or_else(|e| {
+                    tracing::warn!(error = %e, "HnAlgolia client builder failed, using default");
+                    reqwest::Client::new()
+                }),
         }
     }
 

--- a/crates/tome/src/clients/unpaywall.rs
+++ b/crates/tome/src/clients/unpaywall.rs
@@ -26,7 +26,10 @@ impl UnpaywallClient {
             http: reqwest::Client::builder()
                 .timeout(std::time::Duration::from_secs(30))
                 .build()
-                .unwrap_or_else(|_| reqwest::Client::new()),
+                .unwrap_or_else(|e| {
+                    tracing::warn!(error = %e, "Unpaywall client builder failed, using default");
+                    reqwest::Client::new()
+                }),
             email,
         }
     }

--- a/crates/tome/src/knowledge_graph.rs
+++ b/crates/tome/src/knowledge_graph.rs
@@ -97,6 +97,9 @@ impl KnowledgeGraph {
         Ok(kg)
     }
 
+    // NOTE: CREATE TABLE IF NOT EXISTS means FK constraints only apply to new
+    // databases. Pre-existing databases keep the old schema without FKs.
+    // Acceptable pre-1.0; a migration step should be added before 1.0 release.
     fn init_schema(&self) -> TomeResult<()> {
         let conn = self.conn.lock().unwrap_or_else(|p| p.into_inner());
         conn.execute_batch(

--- a/crates/tome/src/models.rs
+++ b/crates/tome/src/models.rs
@@ -164,7 +164,10 @@ mod tests {
             "discussion_count": 0
         }"#;
         let result = serde_json::from_str::<ResearchSession>(old_json);
-        assert!(result.is_err(), "Old 'timestamp' field should not deserialize into new struct");
+        assert!(
+            result.is_err(),
+            "Old 'timestamp' field should not deserialize into new struct"
+        );
     }
 }
 

--- a/crates/tome/src/models.rs
+++ b/crates/tome/src/models.rs
@@ -126,6 +126,46 @@ mod tests {
         let roundtripped: DiscussionSource = serde_json::from_str(&json).unwrap();
         assert_eq!(roundtripped, DiscussionSource::HackerNews);
     }
+
+    #[test]
+    fn research_session_roundtrip() {
+        let ts = time::OffsetDateTime::parse(
+            "2024-06-15T10:30:00Z",
+            &time::format_description::well_known::Rfc3339,
+        )
+        .unwrap();
+
+        let session = ResearchSession {
+            id: "sess-1".to_string(),
+            query: "rust async".to_string(),
+            created_at: ts,
+            paper_count: 5,
+            discussion_count: 3,
+        };
+
+        let json = serde_json::to_string(&session).unwrap();
+        assert!(json.contains("2024-06-15T10:30:00Z"));
+
+        let roundtripped: ResearchSession = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtripped.created_at, ts);
+        assert_eq!(roundtripped.paper_count, 5);
+    }
+
+    #[test]
+    fn research_session_legacy_timestamp_field_rejected() {
+        // Old format used field name "timestamp" with a plain string.
+        // After migration to created_at: OffsetDateTime, old JSON is
+        // a breaking change — verify it fails cleanly rather than panicking.
+        let old_json = r#"{
+            "id": "sess-old",
+            "query": "test",
+            "timestamp": "2024-01-01 00:00:00",
+            "paper_count": 1,
+            "discussion_count": 0
+        }"#;
+        let result = serde_json::from_str::<ResearchSession>(old_json);
+        assert!(result.is_err(), "Old 'timestamp' field should not deserialize into new struct");
+    }
 }
 
 /// A cached research session.
@@ -133,7 +173,8 @@ mod tests {
 pub struct ResearchSession {
     pub id: String,
     pub query: String,
-    pub timestamp: String,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: OffsetDateTime,
     pub paper_count: usize,
     pub discussion_count: usize,
 }

--- a/crates/validate/Cargo.toml
+++ b/crates/validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-validate"
-version = "0.7.3"
+version = "0.7.4"
 edition.workspace = true
 description = "Skill validation for Claude Code and Codex CLI"
 license = "MIT"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.7.4 - 2026-04-02
+- **NEW: Research MCP Tools**: 9 tools exposing the `tome` crate over MCP: `search-papers`, `search-discussions`, `resolve-doi`, `fetch-pdf`, `query-knowledge-graph`, `add-knowledge-node`, `link-knowledge`, `track-citations`, and `resolve-contradiction` (27 → 36 tools total).
+- **Fix: Paper Model Refinements**: Improved `Paper` model fields and research handler argument parsing.
+
 ## 0.7.3 - 2026-03-29
 - **NEW: MCP Tool Filtering**: `McpServer` now carries `allowed_tools` and `disabled_tools` fields. All four adapters (Claude, Codex, Copilot, Cursor) read and write these fields, enabling per-server tool whitelists and blacklists during sync.
 - **NEW: MCP Servers Dashboard Panel**: The TUI dashboard displays a dedicated MCP servers panel showing server name, source adapter, transport type, command, and tool filter indicators. The browser dashboard includes a matching panel fetched from `/api/mcp-servers`.

--- a/plugins/skrills/.claude-plugin/plugin.json
+++ b/plugins/skrills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skrills",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Skill synchronization and management for Claude Code, Codex, GitHub Copilot, and Cursor. Provides 27 MCP tools for validation, sync, intelligence, and tracing.",
   "author": {
     "name": "skrills",

--- a/skrills-portal.html
+++ b/skrills-portal.html
@@ -2577,9 +2577,10 @@ Skill instructions..."></textarea>
 
   function runAnalyzeAll() {
     // Simple deterministic hash of a string to a number in [0, range)
-    function nameHash(str, range) {
+    function nameHash(input, range) {
+      if (range === 0) return 0;
       let h = 0;
-      for (let i = 0; i < str.length; i++) { h = (h * 31 + str.charCodeAt(i)) | 0; }
+      for (let i = 0; i < input.length; i++) { h = (h * 31 + input.charCodeAt(i)) | 0; }
       return ((h < 0 ? -h : h) % range);
     }
 


### PR DESCRIPTION
## Summary

- **9 research MCP tools**: `search-papers`, `search-discussions`, `resolve-doi`, `fetch-pdf`, `query-knowledge-graph`, `add-knowledge-node`, `link-knowledge`, `track-citations`, `resolve-contradiction` — exposing the `tome` crate over MCP (27 → 36 tools total)
- **Paper model refinements**: Improved `Paper` model fields (`timestamp` → `created_at: OffsetDateTime`) and research handler argument parsing
- **Version bump**: All 13 workspace crates, inter-crate dependency pins, plugin.json, and Cargo.lock bumped from 0.7.3 → 0.7.4
- **Review fixes**: Batch-resolved issues S8–S14, I7 from PR #188

## Changes

### New: Research MCP Tools (research.rs, 635 LOC)
- **Research API** (#168): `search-papers` (multi-source with DOI dedup), `search-discussions` (HN Algolia), `resolve-doi` (CrossRef + Unpaywall), `fetch-pdf` (OA PDF caching)
- **Advanced** (#169): `query-knowledge-graph` (search/traverse), `add-knowledge-node`, `link-knowledge`, `track-citations` (forward/backward), `resolve-contradiction` (TRIZ matrix)

### Review fixes from PR #188
- `ResearchSession::timestamp` migrated to `created_at: OffsetDateTime`
- Consistent `tracing::warn!` in all 6 tome HTTP client builders
- Log skipped arXiv entries missing id/title
- Remove duplicate `split_frontmatter` test from cursor utils
- Add default sync target integration test
- Portal `nameHash`: rename `str` param, add `range=0` guard
- Document FK migration limitation in citations and knowledge_graph

## Test plan
- [x] `cargo check` passes with all crates at 0.7.4
- [ ] `cargo test` full suite passes
- [ ] No stale 0.7.3 references in source files
- [ ] Research MCP tools functional validation
- [ ] 18 new research tool unit tests pass