### PR TITLE
refactor(tome,server): batch resolve issues #199-#202, docs for 0.7.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4249,7 +4249,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skrills"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "scopeguard",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-analyze"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "parking_lot",
  "regex",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-dashboard"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -4297,7 +4297,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-discovery"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4314,7 +4314,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-intelligence"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4336,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-metrics"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4352,7 +4352,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-server"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-state"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-subagents"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-tome"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-validate"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "proptest",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "skrills_sync"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "skrills_test_utils"
-version = "0.7.4"
+version = "0.7.5"
 dependencies = [
  "tempfile",
 ]

--- a/README.md
+++ b/README.md
@@ -23,11 +23,9 @@ and Cursor.
 [FAQ](docs/FAQ.md) |
 [Changelog](book/src/changelog.md)
 
-> **What's new in 0.7.4** -- 9 research MCP tools
-> (`search-papers`, `search-discussions`, `resolve-doi`, `fetch-pdf`,
-> `query-knowledge-graph`, `add-knowledge-node`, `link-knowledge`,
-> `track-citations`, `resolve-contradiction`) exposing the `tome`
-> crate over MCP (27 → 36 tools total).
+> **What's new in 0.7.5** -- Serde-based enum parsing, hardened error
+> handling for research MCP tools, `OffsetDateTime` timestamps in the
+> knowledge graph, and new round-trip tests for `NodeKind`/`EdgeKind`.
 > See [changelog](book/src/changelog.md).
 
 ## Demo

--- a/README.md
+++ b/README.md
@@ -23,10 +23,30 @@ and Cursor.
 [FAQ](docs/FAQ.md) |
 [Changelog](book/src/changelog.md)
 
-> **What's new in 0.7.5** -- Serde-based enum parsing, hardened error
-> handling for research MCP tools, `OffsetDateTime` timestamps in the
-> knowledge graph, and new round-trip tests for `NodeKind`/`EdgeKind`.
+> **What's new in 0.7.5** -- Serde-based enum parsing for research
+> handlers, `OffsetDateTime` timestamps in the knowledge graph, and
+> hardened error reporting across MCP tools.
 > See [changelog](book/src/changelog.md).
+
+## Why Skrills?
+
+Skills authored for one AI coding assistant rarely work in another.
+Skrills validates, analyzes, and syncs skills across four CLI
+environments from a single Rust binary:
+
+- **One-command sync** -- `skrills sync-all` mirrors skills,
+  commands, agents, MCP servers, rules, and preferences between
+  Claude Code, Codex CLI, Copilot CLI, and Cursor.
+- **Validation with autofix** -- detects missing frontmatter,
+  incompatible fields, and body issues across each target's
+  requirements, then fixes them with `--autofix`.
+- **36-tool MCP server** -- exposes validation, sync,
+  intelligence, and research operations over stdio or HTTP so
+  other tools can call Skrills programmatically.
+
+See [comparison](book/src/comparison.md) for how Skrills differs
+from static skill bundles, rules repositories, and local sync
+CLIs.
 
 ## Demo
 
@@ -43,32 +63,25 @@ setup.
 
 ## Features
 
-- **Cross-CLI validation** -- validates skills against Claude Code
-  (permissive), Codex CLI (strict), Copilot CLI (strict), and Cursor
-  rules. Auto-derives missing YAML frontmatter from file paths and
-  content.
-- **Multi-directional sync** -- syncs skills, commands, agents, MCP
-  servers, rules, and preferences across all four environments. Uses
-  file hashing to respect manual edits so user changes are not
-  overwritten.
-- **Token analytics** -- measures token usage per skill and suggests
-  reductions to fit context windows.
-- **Dependency resolution** -- resolves skill dependencies with cycle
-  detection and semantic versioning constraints.
-- **MCP server** -- 36 tools for validation, sync, intelligence,
-  research, and project-aware skill generation over stdio or HTTP
-  transport.
+- **Cross-CLI validation** -- validates against Claude Code
+  (permissive), Codex CLI (strict), Copilot CLI (strict), and
+  Cursor rules. Auto-derives missing YAML frontmatter.
+- **Multi-directional sync** -- syncs seven asset types across
+  four CLIs. File hashing preserves manual edits.
+- **Token analytics** -- per-skill token counts with reduction
+  suggestions for context-window management.
+- **Dependency resolution** -- cycle detection and semver
+  constraints across skill graphs.
+- **MCP server** -- 36 tools over stdio or HTTP for validation,
+  sync, intelligence, research, and skill generation.
 - **Session mining** -- parses Claude Code and Codex CLI session
-  history to improve recommendations based on actual usage.
-- **Visualization** -- TUI and browser dashboard showing discovered
-  skills, validation status, usage metrics, and MCP server
-  configurations with tool filter indicators. The browser dashboard
-  supports light and dark modes. The standalone
-  [`skrills-portal.html`](skrills-portal.html) can be opened directly
-  in a browser or uploaded to integration platforms without a running
-  server.
+  history to improve recommendations.
+- **Dashboards** -- TUI and browser UIs showing skills,
+  validation status, usage metrics, and MCP server configs.
+  The standalone [`skrills-portal.html`](skrills-portal.html)
+  works offline without a running server.
 - **Discovery deduplication** -- frontmatter identity matching
-  consolidates the same skill installed in multiple locations.
+  consolidates duplicate skill installations.
 
 ## Installation
 
@@ -114,7 +127,8 @@ skrills multi-cli-agent my-agent
 ```
 
 See [CLI reference](book/src/cli.md) for all commands including
-skill lifecycle management.
+skill lifecycle management (`skill-deprecate`, `skill-rollback`,
+`skill-import`, `skill-score`, `skill-catalog`).
 
 ## Supported Environments
 
@@ -136,20 +150,6 @@ derivation (`alwaysApply`, glob-scoped, agent-requested).
 See [ADR 0006](docs/adr/0006-cursor-rules-mapping.md) for the
 mapping strategy and [sync guide](book/src/sync-guide.md) for
 workflows.
-
-## Skill Management
-
-```bash
-# Deprecate, rollback, import, or score skills
-skrills skill-deprecate old-skill --replacement "new-skill"
-skrills skill-rollback my-skill --version abc123
-skrills skill-import https://example.com/skill.md
-skrills skill-score
-```
-
-See [CLI reference](book/src/cli.md) for the full set of
-`skill-*` subcommands (`skill-catalog`, `skill-profile`,
-`skill-usage-report`).
 
 ## Architecture
 
@@ -201,7 +201,7 @@ subcommand) and [FAQ](docs/FAQ.md) for environment variables.
 | [Security](docs/security.md) | Auth, TLS, threat model |
 | [Changelog](book/src/changelog.md) | Release history |
 
-## Limitations
+## Known Limitations
 
 - **No runtime skill injection**: Skrills validates and syncs
   files; it does not inject skills into prompts at runtime.

--- a/book/src/changelog.md
+++ b/book/src/changelog.md
@@ -1,5 +1,12 @@
 # Changelog Highlights
 
+## 0.7.5 (2026-04-07)
+
+- **Refactor: Research Handlers**: Serde-based enum parsing, module-level imports, and hardened error handling for research MCP tools.
+- **Fix: Error Reporting**: `search-papers` now returns `is_error: true` when all sources fail. PDF downloads validate HTTP status. Unpaywall errors are logged.
+- **Refactor: Knowledge Graph Timestamps**: `Node.created_at` uses `OffsetDateTime` with RFC 3339 serde instead of raw strings.
+- **Testing**: Enum round-trip tests for `NodeKind` and `EdgeKind`, cache directory creation test.
+
 ## 0.7.4 (2026-04-02)
 
 - **NEW: Research MCP Tools**: 9 tools expose the `tome` crate over MCP -- `search-papers`, `search-discussions`, `resolve-doi`, `fetch-pdf`, `query-knowledge-graph`, `add-knowledge-node`, `link-knowledge`, `track-citations`, `resolve-contradiction` (27 → 36 tools).

--- a/book/src/changelog.md
+++ b/book/src/changelog.md
@@ -5,7 +5,8 @@
 - **Refactor: Research Handlers**: Serde-based enum parsing, module-level imports, and hardened error handling for research MCP tools.
 - **Fix: Error Reporting**: `search-papers` now returns `is_error: true` when all sources fail. PDF downloads validate HTTP status. Unpaywall errors are logged.
 - **Refactor: Knowledge Graph Timestamps**: `Node.created_at` uses `OffsetDateTime` with RFC 3339 serde instead of raw strings.
-- **Testing**: Enum round-trip tests for `NodeKind` and `EdgeKind`, cache directory creation test.
+- **Fix: Snake-Case Tool Aliases**: Research MCP tools accept both `search-papers` and `search_papers` forms for cross-client compatibility.
+- **Testing**: Enum round-trip tests for `NodeKind` and `EdgeKind`, cache directory creation test, handler dispatch tests for snake_case aliases.
 
 ## 0.7.4 (2026-04-02)
 

--- a/book/src/changelog.md
+++ b/book/src/changelog.md
@@ -5,8 +5,10 @@
 - **Refactor: Research Handlers**: Serde-based enum parsing, module-level imports, and hardened error handling for research MCP tools.
 - **Fix: Error Reporting**: `search-papers` now returns `is_error: true` when all sources fail. PDF downloads validate HTTP status. Unpaywall errors are logged.
 - **Refactor: Knowledge Graph Timestamps**: `Node.created_at` uses `OffsetDateTime` with RFC 3339 serde instead of raw strings.
-- **Fix: Snake-Case Tool Aliases**: Research MCP tools accept both `search-papers` and `search_papers` forms for cross-client compatibility.
-- **Testing**: Enum round-trip tests for `NodeKind` and `EdgeKind`, cache directory creation test, handler dispatch tests for snake_case aliases.
+- **Fix: Snake-Case Tool Names**: All 36 MCP tools accept both kebab-case and snake_case names via universal normalization in `call_tool()` dispatch.
+- **Fix: Legacy Timestamp Fallback**: `parse_rfc3339` falls back to SQLite's `datetime('now')` format for pre-0.7.5 knowledge graph databases, treating legacy timestamps as UTC.
+- **Refactor: Cache Directory Dedup**: `ResearchCache::open()` delegates to `Self::cache_dir()`, eliminating duplicated path logic.
+- **Testing**: Enum round-trip tests for `NodeKind` and `EdgeKind`, cache directory creation test, legacy and RFC 3339 timestamp parse tests.
 
 ## 0.7.4 (2026-04-02)
 

--- a/crates/analyze/Cargo.toml
+++ b/crates/analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-analyze"
-version = "0.7.4"
+version = "0.7.5"
 edition.workspace = true
 description = "Skill analysis: token counting, dependencies, and optimization"
 license = "MIT"
@@ -19,8 +19,8 @@ walkdir = { workspace = true }
 thiserror = { workspace = true }
 semver = { workspace = true }
 tracing = { workspace = true }
-skrills-validate = { path = "../validate", version = "0.7.4" }
-skrills-discovery = { path = "../discovery", version = "0.7.4" }
+skrills-validate = { path = "../validate", version = "0.7.5" }
+skrills-discovery = { path = "../discovery", version = "0.7.5" }
 parking_lot = { workspace = true }
 
 [dev-dependencies]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 description = "A command-line interface and MCP server for managing local SKILL.md files."
 license = "MIT"
@@ -19,7 +19,7 @@ subagents = ["skrills-server/subagents"]
 http-transport = ["skrills-server/http-transport"]
 
 [dependencies]
-skrills-server = { path = "../server", version = "0.7.4" }
+skrills-server = { path = "../server", version = "0.7.5" }
 anyhow.workspace = true
 
 [dev-dependencies]

--- a/crates/dashboard/Cargo.toml
+++ b/crates/dashboard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-dashboard"
-version = "0.7.4"
+version = "0.7.5"
 edition.workspace = true
 description = "Terminal UI dashboard for skrills metrics and monitoring"
 license = "MIT"
@@ -13,9 +13,9 @@ categories = ["development-tools", "visualization"]
 publish = true
 
 [dependencies]
-skrills-metrics = { path = "../metrics", version = "0.7.4" }
-skrills-discovery = { path = "../discovery", version = "0.7.4" }
-skrills_sync = { path = "../sync", version = "0.7.4" }
+skrills-metrics = { path = "../metrics", version = "0.7.5" }
+skrills-discovery = { path = "../discovery", version = "0.7.5" }
+skrills_sync = { path = "../sync", version = "0.7.5" }
 
 # TUI
 ratatui = "0.30"

--- a/crates/discovery/Cargo.toml
+++ b/crates/discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-discovery"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 description = "Filesystem discovery and hashing utilities used by the skrills MCP server."
 license = "MIT"

--- a/crates/intelligence/Cargo.toml
+++ b/crates/intelligence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-intelligence"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 description = "Intelligent skill recommendations based on usage patterns and project context."
 license = "MIT"

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-metrics"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 description = "SQLite-based metrics collection for skrills skill invocations, validations, and sync events."
 license = "MIT"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-server"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 description = "Core library for the skrills MCP server: discovery, filtering, manifest generation, and runtime control."
 license = "MIT"
@@ -45,18 +45,18 @@ rcgen = { version = "0.14", optional = true }
 x509-parser = { version = "0.18", optional = true }
 time.workspace = true
 
-skrills-subagents = { path = "../subagents", version = "0.7.4", optional = true }
+skrills-subagents = { path = "../subagents", version = "0.7.5", optional = true }
 
-skrills-discovery = { path = "../discovery", version = "0.7.4" }
-skrills-state = { path = "../state", version = "0.7.4" }
-skrills_sync = { path = "../sync", version = "0.7.4" }
-skrills-validate = { path = "../validate", version = "0.7.4" }
-skrills-analyze = { path = "../analyze", version = "0.7.4" }
-skrills-intelligence = { path = "../intelligence", version = "0.7.4" }
-skrills-metrics = { path = "../metrics", version = "0.7.4" }
-skrills-tome = { path = "../tome", version = "0.7.4" }
+skrills-discovery = { path = "../discovery", version = "0.7.5" }
+skrills-state = { path = "../state", version = "0.7.5" }
+skrills_sync = { path = "../sync", version = "0.7.5" }
+skrills-validate = { path = "../validate", version = "0.7.5" }
+skrills-analyze = { path = "../analyze", version = "0.7.5" }
+skrills-intelligence = { path = "../intelligence", version = "0.7.5" }
+skrills-metrics = { path = "../metrics", version = "0.7.5" }
+skrills-tome = { path = "../tome", version = "0.7.5" }
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
-skrills-dashboard = { path = "../dashboard", version = "0.7.4", optional = true }
+skrills-dashboard = { path = "../dashboard", version = "0.7.5", optional = true }
 shellexpand = "3"
 regex = "1"
 sha2.workspace = true

--- a/crates/server/src/app/research.rs
+++ b/crates/server/src/app/research.rs
@@ -3,23 +3,28 @@
 //! Implements MCP tool handlers for academic research API orchestration,
 //! knowledge graph management, citation tracking, and TRIZ contradiction resolution.
 
+use std::collections::HashSet;
+
 use anyhow::{anyhow, Result};
 use rmcp::model::{CallToolResult, Content};
 use serde_json::{json, Map as JsonMap, Value};
 
+use skrills_tome::cache::ResearchCache;
+use skrills_tome::citations::CitationTracker;
+use skrills_tome::clients::{
+    arxiv::ArxivClient, crossref::CrossRefClient, hn_algolia::HnAlgoliaClient,
+    openalex::OpenAlexClient, semantic_scholar::SemanticScholarClient,
+    unpaywall::UnpaywallClient,
+};
+use skrills_tome::knowledge_graph::{EdgeKind, KnowledgeGraph, NodeKind};
+use skrills_tome::models::{Paper, PaperSource};
+use skrills_tome::triz::{Parameter, TrizMatrix};
+
 use crate::app::SkillService;
 
 /// Resolve the skrills-tome cache directory.
-///
-/// Mirrors the logic in `ResearchCache::open()` so that the knowledge graph
-/// and citation databases land alongside the API cache.
 fn tome_cache_dir() -> Result<std::path::PathBuf> {
-    let base = dirs::cache_dir()
-        .or_else(|| dirs::home_dir().map(|h| h.join(".cache")))
-        .ok_or_else(|| anyhow!("cannot determine cache directory: HOME is unset"))?;
-    let dir = base.join("skrills-tome");
-    std::fs::create_dir_all(&dir)?;
-    Ok(dir)
+    Ok(ResearchCache::cache_dir()?)
 }
 
 impl SkillService {
@@ -29,12 +34,6 @@ impl SkillService {
         &self,
         args: JsonMap<String, Value>,
     ) -> Result<CallToolResult> {
-        use skrills_tome::clients::arxiv::ArxivClient;
-        use skrills_tome::clients::openalex::OpenAlexClient;
-        use skrills_tome::clients::semantic_scholar::SemanticScholarClient;
-        use skrills_tome::models::Paper;
-        use std::collections::HashSet;
-
         let query = args
             .get("query")
             .and_then(|v| v.as_str())
@@ -110,9 +109,13 @@ impl SkillService {
             })
             .collect();
 
+        let all_failed = deduped.is_empty() && !errors.is_empty();
         let mut text = format!("Found {} papers", deduped.len());
         if !errors.is_empty() {
             text.push_str(&format!(" ({} source errors)", errors.len()));
+        }
+        if all_failed {
+            text.push_str(": all sources failed");
         }
 
         Ok(CallToolResult {
@@ -122,7 +125,7 @@ impl SkillService {
                 "count": deduped.len(),
                 "errors": errors,
             })),
-            is_error: Some(false),
+            is_error: Some(all_failed),
             meta: None,
         })
     }
@@ -131,13 +134,15 @@ impl SkillService {
         &self,
         args: JsonMap<String, Value>,
     ) -> Result<CallToolResult> {
-        use skrills_tome::clients::hn_algolia::HnAlgoliaClient;
-
         let query = args
             .get("query")
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow!("Missing required parameter: query"))?;
-        let limit = args.get("limit").and_then(|v| v.as_u64()).unwrap_or(10) as usize;
+        let limit = args
+            .get("limit")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(10)
+            .min(100) as usize;
 
         let client = HnAlgoliaClient::new();
         let discussions = client.search(query, limit).await?;
@@ -178,9 +183,6 @@ impl SkillService {
         &self,
         args: JsonMap<String, Value>,
     ) -> Result<CallToolResult> {
-        use skrills_tome::clients::crossref::CrossRefClient;
-        use skrills_tome::clients::unpaywall::UnpaywallClient;
-
         let doi = args
             .get("doi")
             .and_then(|v| v.as_str())
@@ -190,7 +192,13 @@ impl SkillService {
         let metadata = crossref.resolve_doi(doi).await?;
 
         let unpaywall = UnpaywallClient::default();
-        let pdf_url = unpaywall.find_pdf_url(doi).await.unwrap_or(None);
+        let pdf_url = match unpaywall.find_pdf_url(doi).await {
+            Ok(url) => url,
+            Err(e) => {
+                tracing::warn!(doi = doi, error = %e, "Unpaywall lookup failed");
+                None
+            }
+        };
 
         Ok(CallToolResult {
             content: vec![Content::text(format!(
@@ -217,9 +225,6 @@ impl SkillService {
         &self,
         args: JsonMap<String, Value>,
     ) -> Result<CallToolResult> {
-        use skrills_tome::cache::ResearchCache;
-        use skrills_tome::clients::unpaywall::UnpaywallClient;
-
         let doi = args
             .get("doi")
             .and_then(|v| v.as_str())
@@ -238,8 +243,18 @@ impl SkillService {
 
         // Download if not already cached
         if !pdf_path.exists() {
-            let client = reqwest::Client::new();
-            let bytes = client.get(&pdf_url).send().await?.bytes().await?;
+            let client = reqwest::Client::builder()
+                .timeout(std::time::Duration::from_secs(30))
+                .build()?;
+            let resp = client.get(&pdf_url).send().await?;
+            if !resp.status().is_success() {
+                return Err(anyhow!(
+                    "PDF download failed with HTTP {}: {}",
+                    resp.status().as_u16(),
+                    pdf_url
+                ));
+            }
+            let bytes = resp.bytes().await?;
             std::fs::write(&pdf_path, &bytes)?;
         }
 
@@ -264,8 +279,6 @@ impl SkillService {
         &self,
         args: JsonMap<String, Value>,
     ) -> Result<CallToolResult> {
-        use skrills_tome::knowledge_graph::{KnowledgeGraph, NodeKind};
-
         let db_path = tome_cache_dir()?.join("knowledge.db");
         let kg = KnowledgeGraph::open(&db_path)?;
 
@@ -314,16 +327,14 @@ impl SkillService {
                 meta: None,
             })
         } else if let Some(query) = args.get("query").and_then(|v| v.as_str()) {
-            let kind = args
-                .get("kind")
-                .and_then(|v| v.as_str())
-                .and_then(|k| match k {
-                    "topic" => Some(NodeKind::Topic),
-                    "paper" => Some(NodeKind::Paper),
-                    "implementation" => Some(NodeKind::Implementation),
-                    "discussion" => Some(NodeKind::Discussion),
-                    _ => None,
-                });
+            let kind = match args.get("kind").and_then(|v| v.as_str()) {
+                Some(s) => {
+                    let k: NodeKind = serde_json::from_value(json!(s))
+                        .map_err(|_| anyhow!("Unknown node kind: {s}"))?;
+                    Some(k)
+                }
+                None => None,
+            };
 
             let nodes = kg.search_nodes(query, kind)?;
             let node_json: Vec<Value> = nodes
@@ -364,8 +375,6 @@ impl SkillService {
         &self,
         args: JsonMap<String, Value>,
     ) -> Result<CallToolResult> {
-        use skrills_tome::knowledge_graph::{KnowledgeGraph, NodeKind};
-
         let id = args
             .get("id")
             .and_then(|v| v.as_str())
@@ -380,13 +389,8 @@ impl SkillService {
             .ok_or_else(|| anyhow!("Missing required parameter: label"))?;
         let metadata = args.get("metadata").map(|v| v.to_string());
 
-        let kind = match kind_str {
-            "topic" => NodeKind::Topic,
-            "paper" => NodeKind::Paper,
-            "implementation" => NodeKind::Implementation,
-            "discussion" => NodeKind::Discussion,
-            other => return Err(anyhow!("Unknown node kind: {other}")),
-        };
+        let kind: NodeKind = serde_json::from_value(json!(kind_str))
+            .map_err(|_| anyhow!("Unknown node kind: {kind_str}"))?;
 
         let db_path = tome_cache_dir()?.join("knowledge.db");
         let kg = KnowledgeGraph::open(&db_path)?;
@@ -406,8 +410,6 @@ impl SkillService {
         &self,
         args: JsonMap<String, Value>,
     ) -> Result<CallToolResult> {
-        use skrills_tome::knowledge_graph::{EdgeKind, KnowledgeGraph};
-
         let source_id = args
             .get("source_id")
             .and_then(|v| v.as_str())
@@ -423,14 +425,8 @@ impl SkillService {
         let weight = args.get("weight").and_then(|v| v.as_f64()).unwrap_or(1.0);
         let metadata = args.get("metadata").map(|v| v.to_string());
 
-        let kind = match kind_str {
-            "cites" => EdgeKind::Cites,
-            "implements" => EdgeKind::Implements,
-            "contradicts" => EdgeKind::Contradicts,
-            "extends" => EdgeKind::Extends,
-            "analogous_to" => EdgeKind::AnalogousTo,
-            other => return Err(anyhow!("Unknown edge kind: {other}")),
-        };
+        let kind: EdgeKind = serde_json::from_value(json!(kind_str))
+            .map_err(|_| anyhow!("Unknown edge kind: {kind_str}"))?;
 
         let db_path = tome_cache_dir()?.join("knowledge.db");
         let kg = KnowledgeGraph::open(&db_path)?;
@@ -455,9 +451,6 @@ impl SkillService {
         &self,
         args: JsonMap<String, Value>,
     ) -> Result<CallToolResult> {
-        use skrills_tome::citations::CitationTracker;
-        use skrills_tome::models::{Paper, PaperSource};
-
         let paper_id = args
             .get("paper_id")
             .and_then(|v| v.as_str())
@@ -564,8 +557,6 @@ impl SkillService {
         &self,
         args: JsonMap<String, Value>,
     ) -> Result<CallToolResult> {
-        use skrills_tome::triz::TrizMatrix;
-
         let improve_str = args
             .get("improve")
             .and_then(|v| v.as_str())
@@ -612,24 +603,7 @@ impl SkillService {
     }
 }
 
-fn parse_parameter(s: &str) -> Result<skrills_tome::triz::Parameter> {
-    use skrills_tome::triz::Parameter;
-    match s {
-        "performance" => Ok(Parameter::Performance),
-        "reliability" => Ok(Parameter::Reliability),
-        "maintainability" => Ok(Parameter::Maintainability),
-        "scalability" => Ok(Parameter::Scalability),
-        "security" => Ok(Parameter::Security),
-        "usability" => Ok(Parameter::Usability),
-        "testability" => Ok(Parameter::Testability),
-        "deployability" => Ok(Parameter::Deployability),
-        "cost_efficiency" => Ok(Parameter::CostEfficiency),
-        "development_speed" => Ok(Parameter::DevelopmentSpeed),
-        "code_complexity" => Ok(Parameter::CodeComplexity),
-        "memory_usage" => Ok(Parameter::MemoryUsage),
-        "latency" => Ok(Parameter::Latency),
-        "throughput" => Ok(Parameter::Throughput),
-        "availability" => Ok(Parameter::Availability),
-        other => Err(anyhow!("Unknown parameter: {other}")),
-    }
+fn parse_parameter(s: &str) -> Result<Parameter> {
+    serde_json::from_value(serde_json::Value::String(s.to_owned()))
+        .map_err(|_| anyhow!("Unknown parameter: {s}"))
 }

--- a/crates/server/src/app/research.rs
+++ b/crates/server/src/app/research.rs
@@ -13,8 +13,7 @@ use skrills_tome::cache::ResearchCache;
 use skrills_tome::citations::CitationTracker;
 use skrills_tome::clients::{
     arxiv::ArxivClient, crossref::CrossRefClient, hn_algolia::HnAlgoliaClient,
-    openalex::OpenAlexClient, semantic_scholar::SemanticScholarClient,
-    unpaywall::UnpaywallClient,
+    openalex::OpenAlexClient, semantic_scholar::SemanticScholarClient, unpaywall::UnpaywallClient,
 };
 use skrills_tome::knowledge_graph::{EdgeKind, KnowledgeGraph, NodeKind};
 use skrills_tome::models::{Paper, PaperSource};

--- a/crates/server/src/app/tests/research.rs
+++ b/crates/server/src/app/tests/research.rs
@@ -578,6 +578,15 @@ fn research_tool_schemas_have_correct_required_fields() {
     assert!(required.contains(&json!("target_id")));
     assert!(required.contains(&json!("kind")));
 
+    // track-citations requires only "paper_id" (T4: title is optional — only needed for track action)
+    let schema = tool_map["track-citations"].input_schema.as_ref();
+    let required = schema.get("required").unwrap().as_array().unwrap();
+    assert!(required.contains(&json!("paper_id")));
+    assert!(
+        !required.contains(&json!("title")),
+        "title should not be in required — only needed for action=track"
+    );
+
     // resolve-contradiction requires "improve", "degrades"
     let schema = tool_map["resolve-contradiction"].input_schema.as_ref();
     let required = schema.get("required").unwrap().as_array().unwrap();
@@ -613,6 +622,378 @@ fn research_tools_has_all_expected_names() {
             "Expected tool '{}' in research_tools, found: {:?}",
             name,
             names
+        );
+    }
+}
+
+// -------------------------------------------------------------------------
+// T1: query_knowledge_graph_tool search-by-query branch
+// -------------------------------------------------------------------------
+
+/// GIVEN nodes in the knowledge graph
+/// WHEN query_knowledge_graph_tool is called with a query string
+/// THEN it returns matching nodes
+#[test]
+fn query_knowledge_graph_search_by_query() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    // Add a node
+    let args = json!({"id": "topic-search-test", "kind": "topic", "label": "Searchable Topic"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    service.add_knowledge_node_tool(args).unwrap();
+
+    // Search by query
+    let args = json!({"query": "Searchable"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    let result = service.query_knowledge_graph_tool(args).unwrap();
+    assert!(!result.is_error.unwrap_or(true));
+
+    let structured = result.structured_content.unwrap();
+    let nodes = structured.get("nodes").unwrap().as_array().unwrap();
+    assert!(!nodes.is_empty(), "Should find at least one node");
+    assert_eq!(nodes[0].get("id").unwrap(), "topic-search-test");
+}
+
+/// GIVEN nodes in the knowledge graph
+/// WHEN query_knowledge_graph_tool is called with query + kind filter
+/// THEN it filters by kind
+#[test]
+fn query_knowledge_graph_search_with_kind_filter() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    let args = json!({"id": "paper-filter", "kind": "paper", "label": "Filter Test Paper"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    service.add_knowledge_node_tool(args).unwrap();
+
+    let args = json!({"id": "topic-filter", "kind": "topic", "label": "Filter Test Topic"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    service.add_knowledge_node_tool(args).unwrap();
+
+    // Search with kind=paper filter
+    let args = json!({"query": "Filter", "kind": "paper"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    let result = service.query_knowledge_graph_tool(args).unwrap();
+    let structured = result.structured_content.unwrap();
+    let nodes = structured.get("nodes").unwrap().as_array().unwrap();
+
+    for node in nodes {
+        assert_eq!(node.get("kind").unwrap(), "paper");
+    }
+}
+
+/// GIVEN a query with an unknown kind
+/// WHEN query_knowledge_graph_tool is called
+/// THEN it returns an error (I3)
+#[test]
+fn query_knowledge_graph_rejects_unknown_kind() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    let args = json!({"query": "anything", "kind": "banana"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    let err = service.query_knowledge_graph_tool(args).unwrap_err();
+    assert!(
+        err.to_string().contains("Unknown node kind"),
+        "Should reject unknown kind, got: {err}"
+    );
+}
+
+// -------------------------------------------------------------------------
+// T3: track_citations_tool backward action
+// -------------------------------------------------------------------------
+
+/// GIVEN a tracked paper
+/// WHEN track_citations_tool is called with action=backward
+/// THEN it returns backward citations (empty for new paper)
+#[test]
+fn track_citations_backward_empty() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    // Track a paper first
+    let args = json!({
+        "paper_id": "paper-back-001",
+        "action": "track",
+        "title": "Backward Test Paper"
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+    service.track_citations_tool(args).unwrap();
+
+    // Query backward citations
+    let args = json!({
+        "paper_id": "paper-back-001",
+        "action": "backward"
+    })
+    .as_object()
+    .cloned()
+    .unwrap();
+
+    let result = service.track_citations_tool(args).unwrap();
+    assert!(!result.is_error.unwrap_or(true));
+
+    let structured = result.structured_content.unwrap();
+    assert_eq!(structured.get("count").unwrap(), 0);
+    assert_eq!(structured.get("direction").unwrap(), "backward");
+}
+
+// -------------------------------------------------------------------------
+// T5: More edge kinds and direction filters
+// -------------------------------------------------------------------------
+
+/// GIVEN two nodes
+/// WHEN linked with each of the 5 edge kinds
+/// THEN all are accepted
+#[test]
+fn link_knowledge_accepts_all_edge_kinds() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    // Add source and target nodes
+    let add = |id: &str| {
+        let args = json!({"id": id, "kind": "topic", "label": id})
+            .as_object()
+            .cloned()
+            .unwrap();
+        service.add_knowledge_node_tool(args).unwrap();
+    };
+    add("src-node");
+    add("tgt-cites");
+    add("tgt-impl");
+    add("tgt-contra");
+    add("tgt-ext");
+    add("tgt-analog");
+
+    let all_kinds = ["cites", "implements", "contradicts", "extends", "analogous_to"];
+    let targets = [
+        "tgt-cites",
+        "tgt-impl",
+        "tgt-contra",
+        "tgt-ext",
+        "tgt-analog",
+    ];
+
+    for (kind, target) in all_kinds.iter().zip(targets.iter()) {
+        let args = json!({
+            "source_id": "src-node",
+            "target_id": target,
+            "kind": kind,
+        })
+        .as_object()
+        .cloned()
+        .unwrap();
+
+        let result = service.link_knowledge_tool(args);
+        assert!(
+            result.is_ok(),
+            "Edge kind '{}' should be accepted, got: {:?}",
+            kind,
+            result.err()
+        );
+    }
+}
+
+/// GIVEN a node with both incoming and outgoing edges
+/// WHEN query_knowledge_graph_tool is called with direction="to"
+/// THEN only incoming edges are returned
+#[test]
+fn query_knowledge_graph_direction_to() {
+    let _guard = crate::test_support::env_guard();
+    let temp = tempfile::tempdir().unwrap();
+    let _home = crate::test_support::set_env_var("HOME", Some(temp.path().to_str().unwrap()));
+
+    let service = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1)).unwrap();
+
+    let add = |id: &str| {
+        let args = json!({"id": id, "kind": "topic", "label": id})
+            .as_object()
+            .cloned()
+            .unwrap();
+        service.add_knowledge_node_tool(args).unwrap();
+    };
+    add("center");
+    add("outgoing-target");
+    add("incoming-source");
+
+    // center -> outgoing-target
+    let args = json!({"source_id": "center", "target_id": "outgoing-target", "kind": "cites"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    service.link_knowledge_tool(args).unwrap();
+
+    // incoming-source -> center
+    let args = json!({"source_id": "incoming-source", "target_id": "center", "kind": "extends"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    service.link_knowledge_tool(args).unwrap();
+
+    // Query with direction="to" — should get only incoming edges
+    let args = json!({"node_id": "center", "direction": "to"})
+        .as_object()
+        .cloned()
+        .unwrap();
+    let result = service.query_knowledge_graph_tool(args).unwrap();
+    let structured = result.structured_content.unwrap();
+
+    let edges_from = structured.get("edges_from").unwrap().as_array().unwrap();
+    let edges_to = structured.get("edges_to").unwrap().as_array().unwrap();
+    assert!(edges_from.is_empty(), "direction=to should have no outgoing edges");
+    assert_eq!(edges_to.len(), 1);
+    assert_eq!(edges_to[0].get("source").unwrap(), "incoming-source");
+}
+
+// -------------------------------------------------------------------------
+// I5: Enum sync test — verify TRIZ parameter, NodeKind, and EdgeKind
+//     enums are consistent between schema and handler
+// -------------------------------------------------------------------------
+
+/// GIVEN the resolve-contradiction schema enum values
+/// WHEN compared against Parameter::all() (canonical source)
+/// THEN they match exactly
+#[test]
+fn triz_parameter_enum_matches_schema() {
+    use crate::tool_schemas::research_tools;
+    use skrills_tome::triz::Parameter;
+
+    let tools = research_tools();
+    let tool = tools
+        .iter()
+        .find(|t| t.name.as_ref() == "resolve-contradiction")
+        .unwrap();
+
+    let schema = tool.input_schema.as_ref();
+    let props = schema.get("properties").unwrap();
+    let improve_enum = props
+        .get("improve")
+        .unwrap()
+        .get("enum")
+        .unwrap()
+        .as_array()
+        .unwrap();
+
+    let schema_values: Vec<&str> = improve_enum.iter().filter_map(|v| v.as_str()).collect();
+    let enum_values: Vec<&str> = Parameter::all().iter().map(|p| p.as_str()).collect();
+
+    assert_eq!(
+        schema_values.len(),
+        enum_values.len(),
+        "Schema enum count ({}) != Parameter::all() count ({})",
+        schema_values.len(),
+        enum_values.len()
+    );
+    for val in &enum_values {
+        assert!(
+            schema_values.contains(val),
+            "Parameter::all() has '{}' but schema enum does not include it",
+            val
+        );
+    }
+}
+
+/// GIVEN the add-knowledge-node schema enum values
+/// WHEN compared against NodeKind::all() (canonical source)
+/// THEN they match exactly
+#[test]
+fn node_kind_enum_matches_schema() {
+    use crate::tool_schemas::research_tools;
+    use skrills_tome::knowledge_graph::NodeKind;
+
+    let tools = research_tools();
+    let tool = tools
+        .iter()
+        .find(|t| t.name.as_ref() == "add-knowledge-node")
+        .unwrap();
+
+    let schema = tool.input_schema.as_ref();
+    let kind_enum = schema
+        .get("properties")
+        .unwrap()
+        .get("kind")
+        .unwrap()
+        .get("enum")
+        .unwrap()
+        .as_array()
+        .unwrap();
+
+    let schema_values: Vec<&str> = kind_enum.iter().filter_map(|v| v.as_str()).collect();
+    let enum_values: Vec<&str> = NodeKind::all().iter().map(|k| k.as_str()).collect();
+
+    assert_eq!(schema_values.len(), enum_values.len());
+    for val in &enum_values {
+        assert!(
+            schema_values.contains(val),
+            "NodeKind::all() has '{}' but schema enum does not",
+            val
+        );
+    }
+}
+
+/// GIVEN the link-knowledge schema enum values
+/// WHEN compared against EdgeKind::all() (canonical source)
+/// THEN they match exactly
+#[test]
+fn edge_kind_enum_matches_schema() {
+    use crate::tool_schemas::research_tools;
+    use skrills_tome::knowledge_graph::EdgeKind;
+
+    let tools = research_tools();
+    let tool = tools
+        .iter()
+        .find(|t| t.name.as_ref() == "link-knowledge")
+        .unwrap();
+
+    let schema = tool.input_schema.as_ref();
+    let kind_enum = schema
+        .get("properties")
+        .unwrap()
+        .get("kind")
+        .unwrap()
+        .get("enum")
+        .unwrap()
+        .as_array()
+        .unwrap();
+
+    let schema_values: Vec<&str> = kind_enum.iter().filter_map(|v| v.as_str()).collect();
+    let enum_values: Vec<&str> = EdgeKind::all().iter().map(|k| k.as_str()).collect();
+
+    assert_eq!(schema_values.len(), enum_values.len());
+    for val in &enum_values {
+        assert!(
+            schema_values.contains(val),
+            "EdgeKind::all() has '{}' but schema enum does not",
+            val
         );
     }
 }

--- a/crates/server/src/app/tests/research.rs
+++ b/crates/server/src/app/tests/research.rs
@@ -649,10 +649,7 @@ fn query_knowledge_graph_search_by_query() {
     service.add_knowledge_node_tool(args).unwrap();
 
     // Search by query
-    let args = json!({"query": "Searchable"})
-        .as_object()
-        .cloned()
-        .unwrap();
+    let args = json!({"query": "Searchable"}).as_object().cloned().unwrap();
     let result = service.query_knowledge_graph_tool(args).unwrap();
     assert!(!result.is_error.unwrap_or(true));
 
@@ -794,7 +791,13 @@ fn link_knowledge_accepts_all_edge_kinds() {
     add("tgt-ext");
     add("tgt-analog");
 
-    let all_kinds = ["cites", "implements", "contradicts", "extends", "analogous_to"];
+    let all_kinds = [
+        "cites",
+        "implements",
+        "contradicts",
+        "extends",
+        "analogous_to",
+    ];
     let targets = [
         "tgt-cites",
         "tgt-impl",
@@ -869,7 +872,10 @@ fn query_knowledge_graph_direction_to() {
 
     let edges_from = structured.get("edges_from").unwrap().as_array().unwrap();
     let edges_to = structured.get("edges_to").unwrap().as_array().unwrap();
-    assert!(edges_from.is_empty(), "direction=to should have no outgoing edges");
+    assert!(
+        edges_from.is_empty(),
+        "direction=to should have no outgoing edges"
+    );
     assert_eq!(edges_to.len(), 1);
     assert_eq!(edges_to[0].get("source").unwrap(), "incoming-source");
 }

--- a/crates/server/src/handler.rs
+++ b/crates/server/src/handler.rs
@@ -906,4 +906,122 @@ mod tests {
             "error message should mention unknown tool"
         );
     }
+
+    // -------------------------------------------------------------------------
+    // Snake-case tool alias dispatch tests (#199)
+    // -------------------------------------------------------------------------
+
+    /// GIVEN a sync research tool called via snake_case name
+    /// WHEN call_tool dispatches the request
+    /// THEN it routes to the correct handler (same as kebab-case)
+    #[test]
+    fn snake_case_aliases_route_sync_research_tools() {
+        let _guard = test_support::env_guard();
+        let temp = tempdir().expect("tempdir");
+        let _home = set_env_var(
+            "HOME",
+            Some(
+                temp.path()
+                    .to_str()
+                    .expect("temp home should be valid utf-8"),
+            ),
+        );
+
+        let service = build_service(&temp);
+
+        // Test resolve_contradiction (snake_case) returns principles, not "unknown tool"
+        let result = run_async(async {
+            let (running, context, _client) = service_with_context(service);
+            running
+                .service()
+                .call_tool(
+                    CallToolRequestParam {
+                        name: "resolve_contradiction".into(),
+                        arguments: Some(
+                            serde_json::json!({
+                                "improve": "performance",
+                                "degrades": "reliability"
+                            })
+                            .as_object()
+                            .cloned()
+                            .unwrap(),
+                        ),
+                    },
+                    context,
+                )
+                .await
+        });
+
+        let res = result.expect("resolve_contradiction should not return unknown tool error");
+        assert!(
+            !res.is_error.unwrap_or(true),
+            "resolve_contradiction should succeed"
+        );
+    }
+
+    /// GIVEN sync research tools called via snake_case names
+    /// WHEN each snake_case alias is dispatched
+    /// THEN none return "unknown tool" errors
+    #[test]
+    fn snake_case_aliases_accepted_for_all_sync_research_tools() {
+        let _guard = test_support::env_guard();
+        let temp = tempdir().expect("tempdir");
+        let _home = set_env_var(
+            "HOME",
+            Some(
+                temp.path()
+                    .to_str()
+                    .expect("temp home should be valid utf-8"),
+            ),
+        );
+
+        // Each (snake_case_name, minimal_valid_args) pair for sync research tools
+        let cases: Vec<(&str, serde_json::Value)> = vec![
+            (
+                "query_knowledge_graph",
+                serde_json::json!({}), // stats mode — no args needed
+            ),
+            (
+                "add_knowledge_node",
+                serde_json::json!({"id": "test-snake", "kind": "topic", "label": "Snake Test"}),
+            ),
+            (
+                "link_knowledge",
+                serde_json::json!({"source_id": "test-snake", "target_id": "test-snake", "kind": "cites"}),
+            ),
+            (
+                "track_citations",
+                serde_json::json!({"paper_id": "p-snake", "action": "track", "title": "Snake Paper"}),
+            ),
+            (
+                "resolve_contradiction",
+                serde_json::json!({"improve": "performance", "degrades": "reliability"}),
+            ),
+        ];
+
+        for (name, args) in cases {
+            let svc = SkillService::new_with_ttl(Vec::new(), Duration::from_secs(1))
+                .expect("service should build");
+            let result = run_async(async move {
+                let (running, context, _client) = service_with_context(svc);
+                running
+                    .service()
+                    .call_tool(
+                        CallToolRequestParam {
+                            name: name.into(),
+                            arguments: Some(args.as_object().cloned().unwrap()),
+                        },
+                        context,
+                    )
+                    .await
+            });
+
+            assert!(
+                result.is_ok(),
+                "snake_case tool '{}' should be dispatched, got error: {:?}",
+                name,
+                result.err()
+            );
+        }
+    }
 }

--- a/crates/server/src/handler.rs
+++ b/crates/server/src/handler.rs
@@ -179,32 +179,17 @@ impl ServerHandler for SkillService {
                     }
                 }
             }
+            let args = request.arguments.clone().unwrap_or_default();
             let result = match request.name.as_ref() {
-                "create-skill" => {
-                    let args = request.arguments.clone().unwrap_or_default();
-                    self.create_skill_tool(args).await
-                }
-                "search-skills-github" => {
-                    let args = request.arguments.clone().unwrap_or_default();
-                    self.search_skills_github_tool(args).await
-                }
+                "create-skill" => self.create_skill_tool(args).await,
+                "search-skills-github" => self.search_skills_github_tool(args).await,
                 // Research tools (async — require HTTP calls to external APIs)
-                "search-papers" => {
-                    let args = request.arguments.clone().unwrap_or_default();
-                    self.search_papers_tool(args).await
-                }
-                "search-discussions" => {
-                    let args = request.arguments.clone().unwrap_or_default();
+                "search-papers" | "search_papers" => self.search_papers_tool(args).await,
+                "search-discussions" | "search_discussions" => {
                     self.search_discussions_tool(args).await
                 }
-                "resolve-doi" => {
-                    let args = request.arguments.clone().unwrap_or_default();
-                    self.resolve_doi_tool(args).await
-                }
-                "fetch-pdf" => {
-                    let args = request.arguments.clone().unwrap_or_default();
-                    self.fetch_pdf_tool(args).await
-                }
+                "resolve-doi" | "resolve_doi" => self.resolve_doi_tool(args).await,
+                "fetch-pdf" | "fetch_pdf" => self.fetch_pdf_tool(args).await,
                 _ => (|| -> Result<CallToolResult> {
                     match request.name.as_ref() {
                     "sync-from-claude" => {
@@ -733,23 +718,23 @@ impl ServerHandler for SkillService {
                         crate::mcp_gateway::get_context_stats(stats)
                     }
                     // Research tools (sync — local database operations)
-                    "query-knowledge-graph" => {
+                    "query-knowledge-graph" | "query_knowledge_graph" => {
                         let args = request.arguments.clone().unwrap_or_default();
                         self.query_knowledge_graph_tool(args)
                     }
-                    "add-knowledge-node" => {
+                    "add-knowledge-node" | "add_knowledge_node" => {
                         let args = request.arguments.clone().unwrap_or_default();
                         self.add_knowledge_node_tool(args)
                     }
-                    "link-knowledge" => {
+                    "link-knowledge" | "link_knowledge" => {
                         let args = request.arguments.clone().unwrap_or_default();
                         self.link_knowledge_tool(args)
                     }
-                    "track-citations" => {
+                    "track-citations" | "track_citations" => {
                         let args = request.arguments.clone().unwrap_or_default();
                         self.track_citations_tool(args)
                     }
-                    "resolve-contradiction" => {
+                    "resolve-contradiction" | "resolve_contradiction" => {
                         let args = request.arguments.clone().unwrap_or_default();
                         self.resolve_contradiction_tool(args)
                     }

--- a/crates/server/src/handler.rs
+++ b/crates/server/src/handler.rs
@@ -179,19 +179,20 @@ impl ServerHandler for SkillService {
                     }
                 }
             }
+            // Normalize snake_case tool names to kebab-case so callers can
+            // use either convention (e.g. "search_papers" -> "search-papers").
+            let canonical_name = request.name.replace('_', "-");
             let args = request.arguments.clone().unwrap_or_default();
-            let result = match request.name.as_ref() {
+            let result = match canonical_name.as_str() {
                 "create-skill" => self.create_skill_tool(args).await,
                 "search-skills-github" => self.search_skills_github_tool(args).await,
                 // Research tools (async — require HTTP calls to external APIs)
-                "search-papers" | "search_papers" => self.search_papers_tool(args).await,
-                "search-discussions" | "search_discussions" => {
-                    self.search_discussions_tool(args).await
-                }
-                "resolve-doi" | "resolve_doi" => self.resolve_doi_tool(args).await,
-                "fetch-pdf" | "fetch_pdf" => self.fetch_pdf_tool(args).await,
+                "search-papers" => self.search_papers_tool(args).await,
+                "search-discussions" => self.search_discussions_tool(args).await,
+                "resolve-doi" => self.resolve_doi_tool(args).await,
+                "fetch-pdf" => self.fetch_pdf_tool(args).await,
                 _ => (|| -> Result<CallToolResult> {
-                    match request.name.as_ref() {
+                    match canonical_name.as_str() {
                     "sync-from-claude" => {
                         let include_marketplace = request
                             .arguments
@@ -692,13 +693,13 @@ impl ServerHandler for SkillService {
                         self.search_skills_fuzzy_tool(args)
                     }
                     // MCP Gateway tools for context optimization
-                    "list-mcp-tools" | "list_mcp_tools" => {
+                    "list-mcp-tools" => {
                         // Get tool entries from the real registry
                         let registry = self.mcp_registry.lock();
                         let entries: Vec<_> = registry.list_all();
                         crate::mcp_gateway::list_mcp_tools(request.arguments.as_ref(), entries)
                     }
-                    "describe-mcp-tool" | "describe_mcp_tool" => {
+                    "describe-mcp-tool" => {
                         // Track schema load for context stats
                         self.context_stats.record_schema_load();
 
@@ -712,29 +713,29 @@ impl ServerHandler for SkillService {
                                 .or_else(|| gateway_tools.iter().find(|t| t.name.as_ref() == name).cloned())
                         })
                     }
-                    "get-context-stats" | "get_context_stats" => {
+                    "get-context-stats" => {
                         // Return current context stats from the real tracker
                         let stats = self.context_stats.snapshot();
                         crate::mcp_gateway::get_context_stats(stats)
                     }
                     // Research tools (sync — local database operations)
-                    "query-knowledge-graph" | "query_knowledge_graph" => {
+                    "query-knowledge-graph" => {
                         let args = request.arguments.clone().unwrap_or_default();
                         self.query_knowledge_graph_tool(args)
                     }
-                    "add-knowledge-node" | "add_knowledge_node" => {
+                    "add-knowledge-node" => {
                         let args = request.arguments.clone().unwrap_or_default();
                         self.add_knowledge_node_tool(args)
                     }
-                    "link-knowledge" | "link_knowledge" => {
+                    "link-knowledge" => {
                         let args = request.arguments.clone().unwrap_or_default();
                         self.link_knowledge_tool(args)
                     }
-                    "track-citations" | "track_citations" => {
+                    "track-citations" => {
                         let args = request.arguments.clone().unwrap_or_default();
                         self.track_citations_tool(args)
                     }
-                    "resolve-contradiction" | "resolve_contradiction" => {
+                    "resolve-contradiction" => {
                         let args = request.arguments.clone().unwrap_or_default();
                         self.resolve_contradiction_tool(args)
                     }
@@ -908,7 +909,7 @@ mod tests {
     }
 
     // -------------------------------------------------------------------------
-    // Snake-case tool alias dispatch tests (#199)
+    // Snake-case tool name normalization tests
     // -------------------------------------------------------------------------
 
     /// GIVEN a sync research tool called via snake_case name

--- a/crates/server/src/tool_schemas.rs
+++ b/crates/server/src/tool_schemas.rs
@@ -6,8 +6,11 @@
 //! - Sync tools: cross-agent synchronization (sync-skills, sync-commands, etc.)
 //! - Validation tools: skill validation and analysis
 //! - Dependency tools: dependency resolution and tracking
+//! - Intelligence tools: context tracking, MCP gateway, skill creation
 //! - Metrics tools: skill statistics and metrics
 //! - Trace tools: skill loading instrumentation
+//! - Recommendation tools: skill search and recommendations
+//! - Research tools: academic paper search, knowledge graphs, citations, TRIZ
 
 use rmcp::model::{Tool, ToolAnnotations};
 use serde_json::{json, Map as JsonMap};
@@ -894,6 +897,7 @@ pub(crate) fn research_tools() -> Vec<Tool> {
                         "limit": {
                             "type": "integer",
                             "default": 10,
+                            "maximum": 100,
                             "description": "Maximum number of results to return"
                         }
                     }),
@@ -1119,7 +1123,7 @@ pub(crate) fn research_tools() -> Vec<Tool> {
                         }
                     }),
                 );
-                schema.insert("required".into(), json!(["paper_id", "title"]));
+                schema.insert("required".into(), json!(["paper_id"]));
                 schema.insert("additionalProperties".into(), json!(false));
                 schema
             }),

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-state"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 description = "State management for skrills runtime options, pins, and persisted overrides."
 license = "MIT"

--- a/crates/subagents/Cargo.toml
+++ b/crates/subagents/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-subagents"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 description = "Subagent MCP tools for the skrills server with pluggable backends."
 license = "MIT"
@@ -28,8 +28,8 @@ thiserror.workspace = true
 tempfile.workspace = true
 toml.workspace = true
 
-skrills-discovery = { path = "../discovery", version = "0.7.4" }
-skrills-state = { path = "../state", version = "0.7.4" }
+skrills-discovery = { path = "../discovery", version = "0.7.5" }
+skrills-state = { path = "../state", version = "0.7.5" }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/crates/sync/Cargo.toml
+++ b/crates/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills_sync"
-version = "0.7.4"
+version = "0.7.5"
 edition.workspace = true
 description = "Preference synchronization and validation sync utilities for skrills"
 license = "MIT"
@@ -20,7 +20,7 @@ sha2.workspace = true
 walkdir.workspace = true
 dirs.workspace = true
 tracing.workspace = true
-skrills-validate = { path = "../validate", version = "0.7.4" }
+skrills-validate = { path = "../validate", version = "0.7.5" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/sync/src/adapters/cursor/skills.rs
+++ b/crates/sync/src/adapters/cursor/skills.rs
@@ -5,18 +5,22 @@
 //! Cursor skills have **no YAML frontmatter** — the content is pure markdown.
 //!
 //! When writing Claude skills to Cursor, YAML frontmatter is stripped.
-//! When reading Cursor skills back, no frontmatter is expected.
+//! The `description` field is preserved as a plain-text first line (Cursor
+//! shows it as the skill subtitle), and `model_hint` is kept as an HTML
+//! comment for routing. When reading Cursor skills back, no frontmatter
+//! is expected.
 //!
 //! ## Lossy roundtrip warning
 //!
-//! Syncing Claude → Cursor **strips YAML frontmatter** (name, description,
-//! dependencies, version, etc.). A subsequent Cursor → Claude sync will
-//! **not** restore that metadata. Treat Cursor as a one-way *consumer*
-//! of Claude skills; do not use it as the source of truth for skills
-//! that originated in Claude.
+//! Syncing Claude → Cursor **strips most YAML frontmatter** (name,
+//! dependencies, version, tags, etc.). `description` and `model_hint`
+//! are preserved in non-YAML form. A subsequent Cursor → Claude sync
+//! will **not** restore the original metadata. Treat Cursor as a
+//! one-way *consumer* of Claude skills; do not use it as the source
+//! of truth for skills that originated in Claude.
 
 use super::paths::skills_dir;
-use super::utils::{extract_model_hint, sanitize_name, strip_frontmatter, trim_skill_body};
+use super::utils::{parse_frontmatter, sanitize_name, strip_yaml_quotes, trim_skill_body};
 use crate::adapters::utils::{collect_module_files, hash_content};
 use crate::common::{Command, ContentFormat};
 use crate::report::{SkipReason, WriteReport};
@@ -101,20 +105,30 @@ pub fn write_skills(root: &Path, skills: &[Command]) -> Result<WriteReport> {
         let skill_dir = dir.join(&name);
         fs::create_dir_all(&skill_dir)?;
 
-        // Strip Claude frontmatter when writing to Cursor
+        // Parse Claude frontmatter to extract metadata before stripping
         let content_str = String::from_utf8_lossy(&skill.content);
+        let (fields, raw_body) = parse_frontmatter(&content_str);
 
-        // Extract model_hint before stripping frontmatter
-        let model_hint = extract_model_hint(&content_str);
+        let description = fields.get("description").map(|d| strip_yaml_quotes(d));
+        let model_hint = fields.get("model_hint").cloned();
 
-        // Strip frontmatter and trim non-essential sections
-        let raw_body = strip_frontmatter(&content_str);
+        // Trim non-essential sections from the body
         let trimmed = trim_skill_body(raw_body);
 
-        // Inject model_hint as a comment at the top if present
-        let body = match model_hint {
-            Some(hint) => format!("<!-- model_hint: {hint} -->\n\n{trimmed}"),
-            None => trimmed,
+        // Inject description as plain text (Cursor shows the first line as
+        // the skill subtitle) and model_hint as an HTML comment for routing.
+        let mut header = String::new();
+        if let Some(desc) = &description {
+            header.push_str(desc);
+            header.push('\n');
+        }
+        if let Some(hint) = &model_hint {
+            header.push_str(&format!("<!-- model_hint: {hint} -->\n"));
+        }
+        let body = if header.is_empty() {
+            trimmed
+        } else {
+            format!("{header}\n{trimmed}")
         };
 
         let skill_path = skill_dir.join("SKILL.md");

--- a/crates/sync/src/adapters/cursor/tests.rs
+++ b/crates/sync/src/adapters/cursor/tests.rs
@@ -94,14 +94,170 @@ fn skills_strip_frontmatter_on_write() {
     let report = adapter.write_skills(&skills).unwrap();
     assert_eq!(report.written, 1);
 
-    // Read back and verify frontmatter was stripped
+    // Read back and verify frontmatter was stripped but description preserved
     let read_back = adapter.read_skills().unwrap();
     assert_eq!(read_back.len(), 1);
     let content = String::from_utf8_lossy(&read_back[0].content);
     assert!(!content.contains("---"), "Frontmatter should be stripped");
     assert!(
+        content.starts_with("A test skill\n"),
+        "Description should be preserved as plain text first line"
+    );
+    assert!(
         content.contains("# test-skill Skill"),
         "Body should be preserved"
+    );
+}
+
+#[test]
+fn skills_description_before_model_hint() {
+    let tmp = TempDir::new().unwrap();
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+
+    let content = "---\nname: paradigms\ndescription: Compare architecture patterns\nmodel_hint: standard\n---\n\n# Paradigms\n\nContent.\n";
+    let skills = vec![make_command("paradigms", content)];
+
+    let report = adapter.write_skills(&skills).unwrap();
+    assert_eq!(report.written, 1);
+
+    let read_back = adapter.read_skills().unwrap();
+    let body = String::from_utf8_lossy(&read_back[0].content);
+
+    assert!(
+        body.starts_with("Compare architecture patterns\n"),
+        "Description should be plain text first line, got: {}",
+        body
+    );
+    assert!(
+        body.contains("<!-- model_hint: standard -->"),
+        "Model hint should be in output"
+    );
+
+    // Description must come before model_hint
+    let desc_pos = body.find("Compare architecture patterns").unwrap();
+    let hint_pos = body.find("<!-- model_hint:").unwrap();
+    assert!(
+        desc_pos < hint_pos,
+        "Description should appear before model_hint so Cursor shows it as the subtitle"
+    );
+}
+
+#[test]
+fn skills_description_strips_yaml_quotes() {
+    let tmp = TempDir::new().unwrap();
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+
+    let content =
+        "---\nname: quoted\ndescription: \"A quoted description\"\n---\n\n# Body\n\nContent.\n";
+    let skills = vec![make_command("quoted", content)];
+
+    adapter.write_skills(&skills).unwrap();
+    let read_back = adapter.read_skills().unwrap();
+    let body = String::from_utf8_lossy(&read_back[0].content);
+    assert!(
+        body.starts_with("A quoted description\n"),
+        "Quotes should be stripped from description, got: {}",
+        body
+    );
+}
+
+#[test]
+fn skills_block_scalar_description() {
+    let tmp = TempDir::new().unwrap();
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+
+    let content = "---\nname: research\ndescription: >-\n  Search GitHub for implementations.\n  Use when the user wants code.\nversion: 1.0\n---\n\n# Body\n";
+    let skills = vec![make_command("research", content)];
+
+    adapter.write_skills(&skills).unwrap();
+    let read_back = adapter.read_skills().unwrap();
+    let body = String::from_utf8_lossy(&read_back[0].content);
+    assert!(
+        body.starts_with("Search GitHub for implementations. Use when the user wants code.\n"),
+        "Block scalar description should be flattened to plain text, got: {}",
+        body
+    );
+}
+
+#[test]
+fn skills_single_quoted_description() {
+    let tmp = TempDir::new().unwrap();
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+
+    let content =
+        "---\nname: single-q\ndescription: 'A single-quoted desc'\n---\n\n# Body\n\nContent.\n";
+    let skills = vec![make_command("single-q", content)];
+
+    adapter.write_skills(&skills).unwrap();
+    let read_back = adapter.read_skills().unwrap();
+    let body = String::from_utf8_lossy(&read_back[0].content);
+    assert!(
+        body.starts_with("A single-quoted desc\n"),
+        "Single quotes should be stripped, got: {}",
+        body
+    );
+}
+
+#[test]
+fn skills_description_only_no_model_hint() {
+    let tmp = TempDir::new().unwrap();
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+
+    let content =
+        "---\nname: plain\ndescription: Just a description\n---\n\n# Content\n\nBody here.\n";
+    let skills = vec![make_command("plain", content)];
+
+    adapter.write_skills(&skills).unwrap();
+    let read_back = adapter.read_skills().unwrap();
+    let body = String::from_utf8_lossy(&read_back[0].content);
+    assert!(
+        body.starts_with("Just a description\n"),
+        "Description should be first line, got: {}",
+        body
+    );
+    assert!(
+        !body.contains("model_hint"),
+        "No model_hint comment when field is absent"
+    );
+    assert!(
+        body.contains("# Content"),
+        "Body should follow the description"
+    );
+}
+
+#[test]
+fn skills_model_hint_only_no_description() {
+    let tmp = TempDir::new().unwrap();
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+
+    let content = "---\nname: hinted\nmodel_hint: fast\n---\n\n# Content\n\nBody here.\n";
+    let skills = vec![make_command("hinted", content)];
+
+    adapter.write_skills(&skills).unwrap();
+    let read_back = adapter.read_skills().unwrap();
+    let body = String::from_utf8_lossy(&read_back[0].content);
+    assert!(
+        body.starts_with("<!-- model_hint: fast -->\n"),
+        "Model hint should be first line when no description, got: {}",
+        body
+    );
+}
+
+#[test]
+fn skills_multiline_quoted_description() {
+    let tmp = TempDir::new().unwrap();
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+
+    let content = "---\nname: modular-monolith\ndescription: 'Single deployable with enforced module\n  boundaries for team autonomy.'\n---\n\n# Content\n";
+    let skills = vec![make_command("modular-monolith", content)];
+
+    adapter.write_skills(&skills).unwrap();
+    let read_back = adapter.read_skills().unwrap();
+    let body = String::from_utf8_lossy(&read_back[0].content);
+    assert!(
+        body.starts_with("Single deployable with enforced module boundaries for team autonomy.\n"),
+        "Multi-line quoted description should be flattened and unquoted, got: {}",
+        body
     );
 }
 
@@ -238,7 +394,7 @@ fn rules_with_globs_preserved() {
 // --- Skills edge cases ---
 
 #[test]
-fn skills_frontmatter_only_content_produces_empty_body() {
+fn skills_frontmatter_only_content_preserves_description() {
     let tmp = TempDir::new().unwrap();
     let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
 
@@ -253,10 +409,10 @@ fn skills_frontmatter_only_content_produces_empty_body() {
     assert_eq!(read_back.len(), 1);
     let body = String::from_utf8_lossy(&read_back[0].content);
     assert!(!body.contains("---"), "Frontmatter should be stripped");
-    // Body may be empty or whitespace-only
     assert!(
-        body.trim().is_empty(),
-        "Body should be empty after stripping frontmatter-only content"
+        body.contains("Has no body"),
+        "Description should be preserved as plain text, got: {}",
+        body
     );
 }
 

--- a/crates/sync/src/adapters/cursor/utils.rs
+++ b/crates/sync/src/adapters/cursor/utils.rs
@@ -14,6 +14,26 @@ use std::sync::LazyLock;
 /// Kept here for backwards compatibility with callers in the cursor adapter.
 pub use crate::adapters::utils::split_frontmatter;
 
+/// Strips matching leading/trailing quotes (`'` or `"`) from a YAML value.
+pub fn strip_yaml_quotes(value: &str) -> String {
+    if value.len() >= 2
+        && ((value.starts_with('"') && value.ends_with('"'))
+            || (value.starts_with('\'') && value.ends_with('\'')))
+    {
+        return value[1..value.len() - 1].to_string();
+    }
+    value.to_string()
+}
+
+/// Returns true if a YAML value starts with a quote but doesn't close it on the same line.
+fn is_open_quoted(value: &str) -> bool {
+    if value.len() < 2 {
+        return false;
+    }
+    (value.starts_with('\'') && !value.ends_with('\''))
+        || (value.starts_with('"') && !value.ends_with('"'))
+}
+
 /// Parses YAML frontmatter from content, returning (frontmatter_fields, body).
 ///
 /// Frontmatter is delimited by `---` on its own line at the start of the file.
@@ -25,18 +45,66 @@ pub fn parse_frontmatter(content: &str) -> (HashMap<String, String>, &str) {
         return (HashMap::new(), body);
     };
 
-    // Parse simple key: value pairs from frontmatter
+    // Parse key: value pairs from frontmatter, handling:
+    // - Block scalars (>-, >, |-, |) with indented continuation
+    // - Quoted multi-line strings ('...\n  ...' or "...\n  ...")
+    // - Simple key: value pairs
     let mut fields = HashMap::new();
+    let mut current_key: Option<String> = None;
+    let mut current_value = String::new();
+    let mut multiline = false;
+
     for line in frontmatter_str.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') {
+        // Indented line: continuation of a multi-line value or list
+        if (line.starts_with(' ') || line.starts_with('\t')) && current_key.is_some() {
+            if multiline {
+                if !current_value.is_empty() {
+                    current_value.push(' ');
+                }
+                current_value.push_str(line.trim());
+            }
+            // Skip list continuation lines (e.g. "  - item") for non-multi-line fields
             continue;
         }
-        if let Some((key, rest)) = line.split_once(':') {
-            let key = key.trim().to_string();
-            let value = rest.trim().to_string();
-            fields.insert(key, value);
+
+        // Flush previous multi-line key — strip quotes from assembled value
+        // since YAML quotes span the full multi-line string.
+        if let Some(key) = current_key.take() {
+            fields.insert(key, strip_yaml_quotes(&current_value));
+            current_value.clear();
+            multiline = false;
         }
+
+        let trimmed = line.trim();
+        if trimmed.is_empty() || trimmed.starts_with('#') {
+            continue;
+        }
+
+        if let Some((key, rest)) = trimmed.split_once(':') {
+            let key = key.trim().to_string();
+            let value = rest.trim();
+
+            if value == ">-" || value == ">" || value == "|-" || value == "|" {
+                // Block scalar: value continues on indented lines
+                current_key = Some(key);
+                multiline = true;
+            } else if is_open_quoted(value) {
+                // Quoted string that spans multiple lines
+                current_key = Some(key);
+                current_value = value.to_string();
+                multiline = true;
+            } else {
+                // Single-line values preserve quotes as-is (needed for
+                // globs like "**/*.ts" in rules). Callers that need
+                // unquoted values use strip_yaml_quotes themselves.
+                fields.insert(key, value.to_string());
+            }
+        }
+    }
+
+    // Flush final key if any
+    if let Some(key) = current_key {
+        fields.insert(key, strip_yaml_quotes(&current_value));
     }
 
     (fields, body)
@@ -81,6 +149,7 @@ pub fn render_frontmatter(fields: &HashMap<String, String>, body: &str) -> Strin
 /// Extracts the `model_hint` value from raw YAML frontmatter.
 ///
 /// Returns the hint (e.g., "fast", "standard", "deep") or None if absent.
+#[cfg(test)]
 pub fn extract_model_hint(content: &str) -> Option<String> {
     let (raw, _) = split_frontmatter(content);
     raw.and_then(|fm| {
@@ -235,6 +304,120 @@ mod tests {
         );
         assert_eq!(sanitize_name("Already-Kebab"), "already-kebab");
         assert_eq!(sanitize_name("file.name.ext"), "file-name-ext");
+    }
+
+    #[test]
+    fn parse_frontmatter_block_scalar_folded_strip() {
+        let content = "---\nname: code-search\ndescription: >-\n  Search GitHub for existing implementations.\n  Use when the user wants to find code.\nversion: 1.0\n---\n\n# Body\n";
+        let (fields, body) = parse_frontmatter(content);
+        assert_eq!(fields.get("name").unwrap(), "code-search");
+        assert_eq!(
+            fields.get("description").unwrap(),
+            "Search GitHub for existing implementations. Use when the user wants to find code."
+        );
+        assert_eq!(fields.get("version").unwrap(), "1.0");
+        assert!(body.starts_with("# Body"));
+    }
+
+    #[test]
+    fn parse_frontmatter_block_scalar_folded() {
+        let content = "---\nname: test\ndescription: >\n  Folded without strip.\nversion: 2.0\n---\n\n# Body\n";
+        let (fields, _body) = parse_frontmatter(content);
+        assert_eq!(fields.get("description").unwrap(), "Folded without strip.");
+        assert_eq!(fields.get("version").unwrap(), "2.0");
+    }
+
+    #[test]
+    fn parse_frontmatter_skips_list_values() {
+        let content = "---\nname: test\ntags:\n  - github\n  - code\nversion: 1.0\n---\n\n# Body\n";
+        let (fields, _body) = parse_frontmatter(content);
+        assert_eq!(fields.get("name").unwrap(), "test");
+        assert_eq!(fields.get("version").unwrap(), "1.0");
+        // tags is a list — stored as empty string since it's `tags:` with no inline value
+        assert_eq!(fields.get("tags").unwrap(), "");
+    }
+
+    #[test]
+    fn parse_frontmatter_multiline_quoted_string() {
+        // YAML flow scalar: opening quote on first line, closing on a continuation line
+        let content = "---\nname: test\ndescription: 'Single deployable with enforced module\n  boundaries for team autonomy.'\nversion: 1.0\n---\n\n# Body\n";
+        let (fields, _body) = parse_frontmatter(content);
+        assert_eq!(
+            fields.get("description").unwrap(),
+            "Single deployable with enforced module boundaries for team autonomy."
+        );
+        assert_eq!(fields.get("version").unwrap(), "1.0");
+    }
+
+    #[test]
+    fn parse_frontmatter_multiline_double_quoted_string() {
+        let content = "---\nname: test\ndescription: \"A multi-line\n  double-quoted value.\"\n---\n\n# Body\n";
+        let (fields, _body) = parse_frontmatter(content);
+        assert_eq!(
+            fields.get("description").unwrap(),
+            "A multi-line double-quoted value."
+        );
+    }
+
+    #[test]
+    fn parse_frontmatter_single_line_quotes_preserved() {
+        // Single-line quoted values keep quotes (needed for globs in rules)
+        let content = "---\nglobs: \"**/*.test.ts\"\ndescription: Testing\n---\n\n# Body\n";
+        let (fields, _body) = parse_frontmatter(content);
+        assert_eq!(
+            fields.get("globs").unwrap(),
+            "\"**/*.test.ts\"",
+            "Single-line quoted values should preserve quotes"
+        );
+    }
+
+    #[test]
+    fn parse_frontmatter_block_scalar_literal() {
+        // `|-` is a literal block scalar (preserves newlines, strips trailing)
+        // Our parser joins with spaces since we only need single-line values.
+        let content =
+            "---\nname: test\ndescription: |-\n  Line one.\n  Line two.\nversion: 3.0\n---\n\n# Body\n";
+        let (fields, _body) = parse_frontmatter(content);
+        assert_eq!(fields.get("description").unwrap(), "Line one. Line two.");
+        assert_eq!(fields.get("version").unwrap(), "3.0");
+    }
+
+    #[test]
+    fn parse_frontmatter_block_scalar_literal_keep() {
+        let content =
+            "---\nname: test\ndescription: |\n  Single line.\nversion: 1.0\n---\n\n# Body\n";
+        let (fields, _body) = parse_frontmatter(content);
+        assert_eq!(fields.get("description").unwrap(), "Single line.");
+    }
+
+    #[test]
+    fn strip_yaml_quotes_double() {
+        assert_eq!(strip_yaml_quotes("\"hello world\""), "hello world");
+    }
+
+    #[test]
+    fn strip_yaml_quotes_single() {
+        assert_eq!(strip_yaml_quotes("'hello world'"), "hello world");
+    }
+
+    #[test]
+    fn strip_yaml_quotes_no_quotes() {
+        assert_eq!(strip_yaml_quotes("hello world"), "hello world");
+    }
+
+    #[test]
+    fn strip_yaml_quotes_mismatched() {
+        assert_eq!(strip_yaml_quotes("\"hello'"), "\"hello'");
+    }
+
+    #[test]
+    fn strip_yaml_quotes_empty() {
+        assert_eq!(strip_yaml_quotes(""), "");
+    }
+
+    #[test]
+    fn strip_yaml_quotes_single_char() {
+        assert_eq!(strip_yaml_quotes("\""), "\"");
     }
 
     #[test]

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills_test_utils"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 license = "Apache-2.0"
 description = "Shared test utilities for skrills crates"

--- a/crates/tome/Cargo.toml
+++ b/crates/tome/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-tome"
-version = "0.7.4"
+version = "0.7.5"
 edition = "2021"
 description = "Research API orchestration, caching, and knowledge graph for skrills."
 license = "MIT"

--- a/crates/tome/src/cache.rs
+++ b/crates/tome/src/cache.rs
@@ -181,4 +181,27 @@ mod tests {
         cache.put("key1", "api", "q", "v2", None).unwrap();
         assert_eq!(cache.get("key1").unwrap(), Some("v2".to_string()));
     }
+
+    /// GIVEN a valid HOME directory
+    /// WHEN ResearchCache::cache_dir() is called
+    /// THEN it returns a path ending in "skrills-tome" and creates the directory
+    #[test]
+    fn cache_dir_creates_directory() {
+        let temp = tempfile::tempdir().unwrap();
+        // Temporarily override HOME so cache_dir() uses our temp dir
+        let prev = std::env::var("HOME").ok();
+        std::env::set_var("HOME", temp.path());
+
+        let result = ResearchCache::cache_dir();
+
+        // Restore HOME
+        match prev {
+            Some(v) => std::env::set_var("HOME", v),
+            None => std::env::remove_var("HOME"),
+        }
+
+        let dir = result.unwrap();
+        assert!(dir.ends_with("skrills-tome"));
+        assert!(dir.exists(), "cache_dir should create the directory");
+    }
 }

--- a/crates/tome/src/cache.rs
+++ b/crates/tome/src/cache.rs
@@ -129,6 +129,21 @@ impl ResearchCache {
     pub fn pdf_dir(&self) -> &std::path::Path {
         &self.pdf_dir
     }
+
+    /// Returns the canonical skrills-tome cache directory, creating it if needed.
+    ///
+    /// Other modules (knowledge graph, citations) should use this instead of
+    /// duplicating the path logic.
+    pub fn cache_dir() -> TomeResult<std::path::PathBuf> {
+        let base = dirs::cache_dir()
+            .or_else(|| dirs::home_dir().map(|h| h.join(".cache")))
+            .ok_or_else(|| {
+                TomeError::Other("cannot determine cache directory: HOME is unset".into())
+            })?;
+        let dir = base.join("skrills-tome");
+        std::fs::create_dir_all(&dir)?;
+        Ok(dir)
+    }
 }
 
 #[cfg(test)]

--- a/crates/tome/src/cache.rs
+++ b/crates/tome/src/cache.rs
@@ -13,14 +13,7 @@ pub struct ResearchCache {
 impl ResearchCache {
     /// Opens or creates the cache database at the default location.
     pub fn open() -> TomeResult<Self> {
-        let cache_dir = dirs::cache_dir()
-            .or_else(|| dirs::home_dir().map(|h| h.join(".cache")))
-            .ok_or_else(|| {
-                TomeError::Other("cannot determine cache directory: HOME is unset".into())
-            })?
-            .join("skrills-tome");
-        std::fs::create_dir_all(&cache_dir)?;
-
+        let cache_dir = Self::cache_dir()?;
         let db_path = cache_dir.join("research.db");
         let pdf_dir = cache_dir.join("pdfs");
         std::fs::create_dir_all(&pdf_dir)?;
@@ -188,19 +181,20 @@ mod tests {
     #[test]
     fn cache_dir_creates_directory() {
         let temp = tempfile::tempdir().unwrap();
-        // Temporarily override HOME so cache_dir() uses our temp dir
         let prev = std::env::var("HOME").ok();
-        std::env::set_var("HOME", temp.path());
 
-        let result = ResearchCache::cache_dir();
+        // Run inside catch_unwind so HOME is always restored even on panic
+        let result = std::panic::catch_unwind(|| {
+            std::env::set_var("HOME", temp.path());
+            ResearchCache::cache_dir()
+        });
 
-        // Restore HOME
         match prev {
             Some(v) => std::env::set_var("HOME", v),
             None => std::env::remove_var("HOME"),
         }
 
-        let dir = result.unwrap();
+        let dir = result.expect("test panicked").unwrap();
         assert!(dir.ends_with("skrills-tome"));
         assert!(dir.exists(), "cache_dir should create the directory");
     }

--- a/crates/tome/src/knowledge_graph.rs
+++ b/crates/tome/src/knowledge_graph.rs
@@ -28,6 +28,8 @@ impl NodeKind {
         }
     }
 
+    /// Returns all variants in declaration order.  Update this list when
+    /// adding a new variant.
     pub fn all() -> &'static [NodeKind] {
         &[
             Self::Topic,
@@ -60,6 +62,8 @@ impl EdgeKind {
         }
     }
 
+    /// Returns all variants in declaration order.  Update this list when
+    /// adding a new variant.
     pub fn all() -> &'static [EdgeKind] {
         &[
             Self::Cites,
@@ -306,9 +310,21 @@ impl KnowledgeGraph {
     }
 }
 
+/// Parse a timestamp string from SQLite TEXT storage into `OffsetDateTime`.
+///
+/// Accepts RFC 3339 (`2026-04-08T12:00:00Z`) and falls back to SQLite's
+/// `datetime('now')` format (`2026-04-08 12:00:00`) for databases created
+/// before the 0.7.5 migration.  Fallback timestamps are treated as UTC.
 fn parse_rfc3339(s: &str) -> TomeResult<OffsetDateTime> {
-    OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339)
-        .map_err(|e| TomeError::Other(format!("invalid RFC 3339 timestamp '{s}': {e}")))
+    OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339).or_else(|_| {
+        // Legacy SQLite datetime format: "YYYY-MM-DD HH:MM:SS" (no timezone)
+        let fmt = time::format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second]")
+            .expect("static format description");
+        tracing::warn!("Parsing legacy timestamp format: '{s}' — consider re-inserting the node to migrate");
+        time::PrimitiveDateTime::parse(s, &fmt)
+            .map(|dt| dt.assume_utc())
+    })
+    .map_err(|e| TomeError::Other(format!("invalid timestamp '{s}': {e}")))
 }
 
 fn parse_node_kind(s: &str) -> TomeResult<NodeKind> {
@@ -453,6 +469,30 @@ mod tests {
             assert_eq!(*kind, parsed, "EdgeKind round-trip failed for '{s}'");
         }
         assert_eq!(all.len(), 5, "EdgeKind::all() should have 5 variants");
+    }
+
+    /// GIVEN a timestamp in SQLite's datetime('now') format
+    /// WHEN parse_rfc3339 is called
+    /// THEN it falls back to the legacy format and returns a valid OffsetDateTime
+    #[test]
+    fn parse_rfc3339_accepts_legacy_sqlite_format() {
+        let legacy = "2025-12-15 10:30:00";
+        let dt = parse_rfc3339(legacy).expect("should parse legacy format");
+        assert_eq!(dt.year(), 2025);
+        assert_eq!(dt.month() as u8, 12);
+        assert_eq!(dt.day(), 15);
+        assert_eq!(dt.hour(), 10);
+        assert_eq!(dt.minute(), 30);
+    }
+
+    /// GIVEN a timestamp in RFC 3339 format
+    /// WHEN parse_rfc3339 is called
+    /// THEN it parses without falling back
+    #[test]
+    fn parse_rfc3339_accepts_rfc3339_format() {
+        let rfc = "2026-04-08T12:00:00Z";
+        let dt = parse_rfc3339(rfc).expect("should parse RFC 3339");
+        assert_eq!(dt.year(), 2026);
     }
 
     #[test]

--- a/crates/tome/src/knowledge_graph.rs
+++ b/crates/tome/src/knowledge_graph.rs
@@ -6,6 +6,7 @@
 use crate::{TomeError, TomeResult};
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
+use time::OffsetDateTime;
 
 /// Node types in the knowledge graph.
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
@@ -25,6 +26,10 @@ impl NodeKind {
             Self::Implementation => "implementation",
             Self::Discussion => "discussion",
         }
+    }
+
+    pub fn all() -> &'static [NodeKind] {
+        &[Self::Topic, Self::Paper, Self::Implementation, Self::Discussion]
     }
 }
 
@@ -49,6 +54,10 @@ impl EdgeKind {
             Self::AnalogousTo => "analogous_to",
         }
     }
+
+    pub fn all() -> &'static [EdgeKind] {
+        &[Self::Cites, Self::Implements, Self::Contradicts, Self::Extends, Self::AnalogousTo]
+    }
 }
 
 /// A node in the knowledge graph.
@@ -58,7 +67,8 @@ pub struct Node {
     pub kind: NodeKind,
     pub label: String,
     pub metadata_json: Option<String>,
-    pub created_at: String,
+    #[serde(with = "time::serde::rfc3339")]
+    pub created_at: OffsetDateTime,
 }
 
 /// An edge between two nodes.
@@ -110,7 +120,7 @@ impl KnowledgeGraph {
                 kind TEXT NOT NULL,
                 label TEXT NOT NULL,
                 metadata_json TEXT,
-                created_at TEXT NOT NULL DEFAULT (datetime('now'))
+                created_at TEXT NOT NULL
             );
 
             CREATE TABLE IF NOT EXISTS edges (
@@ -142,10 +152,13 @@ impl KnowledgeGraph {
         metadata_json: Option<&str>,
     ) -> TomeResult<()> {
         let conn = self.conn.lock().unwrap_or_else(|p| p.into_inner());
+        let now = OffsetDateTime::now_utc()
+            .format(&time::format_description::well_known::Rfc3339)
+            .map_err(|e| TomeError::Other(format!("time format error: {e}")))?;
         conn.execute(
-            "INSERT INTO nodes (id, kind, label, metadata_json) VALUES (?1, ?2, ?3, ?4) \
+            "INSERT INTO nodes (id, kind, label, metadata_json, created_at) VALUES (?1, ?2, ?3, ?4, ?5) \
              ON CONFLICT(id) DO UPDATE SET kind=excluded.kind, label=excluded.label, metadata_json=excluded.metadata_json",
-            rusqlite::params![id, kind.as_str(), label, metadata_json],
+            rusqlite::params![id, kind.as_str(), label, metadata_json, now],
         )?;
         Ok(())
     }
@@ -181,7 +194,8 @@ impl KnowledgeGraph {
                         .map_err(|e| rusqlite::Error::InvalidColumnName(format!("{e}")))?,
                     label: row.get(2)?,
                     metadata_json: row.get(3)?,
-                    created_at: row.get(4)?,
+                    created_at: parse_rfc3339(row.get::<_, String>(4)?.as_str())
+                        .map_err(|e| rusqlite::Error::InvalidColumnName(format!("{e}")))?,
                 })
             },
         );
@@ -208,7 +222,8 @@ impl KnowledgeGraph {
                         .map_err(|e| rusqlite::Error::InvalidColumnName(format!("{e}")))?,
                         label: row.get(2)?,
                         metadata_json: row.get(3)?,
-                        created_at: row.get(4)?,
+                        created_at: parse_rfc3339(row.get::<_, String>(4)?.as_str())
+                            .map_err(|e| rusqlite::Error::InvalidColumnName(format!("{e}")))?,
                     })
                 })?;
                 return rows.collect::<Result<Vec<_>, _>>().map_err(TomeError::Cache);
@@ -223,7 +238,8 @@ impl KnowledgeGraph {
                     .map_err(|e| rusqlite::Error::InvalidColumnName(format!("{e}")))?,
                 label: row.get(2)?,
                 metadata_json: row.get(3)?,
-                created_at: row.get(4)?,
+                created_at: parse_rfc3339(row.get::<_, String>(4)?.as_str())
+                    .map_err(|e| rusqlite::Error::InvalidColumnName(format!("{e}")))?,
             })
         })?;
         rows.collect::<Result<Vec<_>, _>>()
@@ -279,25 +295,19 @@ impl KnowledgeGraph {
     }
 }
 
+fn parse_rfc3339(s: &str) -> TomeResult<OffsetDateTime> {
+    OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339)
+        .map_err(|e| TomeError::Other(format!("invalid RFC 3339 timestamp '{s}': {e}")))
+}
+
 fn parse_node_kind(s: &str) -> TomeResult<NodeKind> {
-    match s {
-        "topic" => Ok(NodeKind::Topic),
-        "paper" => Ok(NodeKind::Paper),
-        "implementation" => Ok(NodeKind::Implementation),
-        "discussion" => Ok(NodeKind::Discussion),
-        other => Err(TomeError::Other(format!("unknown NodeKind: {other}"))),
-    }
+    serde_json::from_value(serde_json::Value::String(s.to_owned()))
+        .map_err(|_| TomeError::Other(format!("unknown NodeKind: {s}")))
 }
 
 fn parse_edge_kind(s: &str) -> TomeResult<EdgeKind> {
-    match s {
-        "cites" => Ok(EdgeKind::Cites),
-        "implements" => Ok(EdgeKind::Implements),
-        "contradicts" => Ok(EdgeKind::Contradicts),
-        "extends" => Ok(EdgeKind::Extends),
-        "analogous_to" => Ok(EdgeKind::AnalogousTo),
-        other => Err(TomeError::Other(format!("unknown EdgeKind: {other}"))),
-    }
+    serde_json::from_value(serde_json::Value::String(s.to_owned()))
+        .map_err(|_| TomeError::Other(format!("unknown EdgeKind: {s}")))
 }
 
 #[cfg(test)]
@@ -385,6 +395,23 @@ mod tests {
         assert_eq!(updated.label, "Updated Label");
         assert_eq!(updated.metadata_json.as_deref(), Some(r#"{"key":"val"}"#));
         assert_eq!(updated.created_at, original.created_at);
+    }
+
+    #[test]
+    fn created_at_is_rfc3339() {
+        let kg = KnowledgeGraph::open_in_memory().unwrap();
+        kg.add_node("ts-1", NodeKind::Topic, "Timestamp Test", None)
+            .unwrap();
+        let node = kg.get_node("ts-1").unwrap().unwrap();
+
+        // Verify created_at roundtrips through serde as RFC 3339
+        let json = serde_json::to_string(&node).unwrap();
+        assert!(
+            json.contains("T") && json.contains("Z"),
+            "created_at should be RFC 3339 format, got: {json}"
+        );
+        let roundtripped: Node = serde_json::from_str(&json).unwrap();
+        assert_eq!(roundtripped.created_at, node.created_at);
     }
 
     #[test]

--- a/crates/tome/src/knowledge_graph.rs
+++ b/crates/tome/src/knowledge_graph.rs
@@ -29,7 +29,12 @@ impl NodeKind {
     }
 
     pub fn all() -> &'static [NodeKind] {
-        &[Self::Topic, Self::Paper, Self::Implementation, Self::Discussion]
+        &[
+            Self::Topic,
+            Self::Paper,
+            Self::Implementation,
+            Self::Discussion,
+        ]
     }
 }
 
@@ -56,7 +61,13 @@ impl EdgeKind {
     }
 
     pub fn all() -> &'static [EdgeKind] {
-        &[Self::Cites, Self::Implements, Self::Contradicts, Self::Extends, Self::AnalogousTo]
+        &[
+            Self::Cites,
+            Self::Implements,
+            Self::Contradicts,
+            Self::Extends,
+            Self::AnalogousTo,
+        ]
     }
 }
 
@@ -412,6 +423,36 @@ mod tests {
         );
         let roundtripped: Node = serde_json::from_str(&json).unwrap();
         assert_eq!(roundtripped.created_at, node.created_at);
+    }
+
+    /// GIVEN NodeKind::all()
+    /// WHEN each variant is round-tripped through as_str + parse
+    /// THEN all variants are covered and parseable
+    #[test]
+    fn node_kind_all_covers_every_variant() {
+        let all = NodeKind::all();
+        // Verify each entry round-trips through serde
+        for kind in all {
+            let s = kind.as_str();
+            let parsed = parse_node_kind(s).unwrap();
+            assert_eq!(*kind, parsed, "NodeKind round-trip failed for '{s}'");
+        }
+        // Verify count matches the enum variants (4 variants)
+        assert_eq!(all.len(), 4, "NodeKind::all() should have 4 variants");
+    }
+
+    /// GIVEN EdgeKind::all()
+    /// WHEN each variant is round-tripped through as_str + parse
+    /// THEN all variants are covered and parseable
+    #[test]
+    fn edge_kind_all_covers_every_variant() {
+        let all = EdgeKind::all();
+        for kind in all {
+            let s = kind.as_str();
+            let parsed = parse_edge_kind(s).unwrap();
+            assert_eq!(*kind, parsed, "EdgeKind round-trip failed for '{s}'");
+        }
+        assert_eq!(all.len(), 5, "EdgeKind::all() should have 5 variants");
     }
 
     #[test]

--- a/crates/validate/Cargo.toml
+++ b/crates/validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-validate"
-version = "0.7.4"
+version = "0.7.5"
 edition.workspace = true
 description = "Skill validation for Claude Code and Codex CLI"
 license = "MIT"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.7.5 - 2026-04-07
+- **Refactor: Research Handlers**: Hoisted function-level imports to module scope in `research.rs`, reducing per-call overhead and improving readability.
+- **Refactor: Serde-Based Parsing**: Replaced manual `match` arms for `NodeKind`, `EdgeKind`, and `Parameter` parsing with `serde_json::from_value`, eliminating duplication between enum definitions and parsers.
+- **Fix: Search Papers Error Reporting**: `search_papers_tool` now sets `is_error: true` when all sources fail, instead of silently returning an empty result.
+- **Fix: Discussion Limit Clamping**: `search_discussions_tool` clamps the `limit` parameter to 100 to prevent excessive API requests.
+- **Fix: PDF Download Hardening**: `fetch_pdf_tool` adds a 30-second timeout and HTTP status check before writing downloaded PDFs.
+- **Fix: Unpaywall Error Logging**: `resolve_doi_tool` logs Unpaywall lookup failures via `tracing::warn` instead of silently swallowing errors.
+- **Refactor: Cache Directory**: Extracted `ResearchCache::cache_dir()` as the canonical source for the skrills-tome cache path, replacing duplicated logic in the server crate.
+- **Refactor: Knowledge Graph Timestamps**: Changed `Node.created_at` from `String` to `OffsetDateTime` with RFC 3339 serde, ensuring type-safe timestamp handling.
+- **Refactor: Enum Helpers**: Added `NodeKind::all()` and `EdgeKind::all()` for exhaustive enumeration, used by schema sync tests.
+- **Testing**: Added `cache_dir_creates_directory`, `node_kind_all_covers_every_variant`, and `edge_kind_all_covers_every_variant` tests in the tome crate.
+
 ## 0.7.4 - 2026-04-02
 - **NEW: Research MCP Tools**: 9 tools exposing the `tome` crate over MCP: `search-papers`, `search-discussions`, `resolve-doi`, `fetch-pdf`, `query-knowledge-graph`, `add-knowledge-node`, `link-knowledge`, `track-citations`, and `resolve-contradiction` (27 → 36 tools total).
 - **Fix: Paper Model Refinements**: Improved `Paper` model fields and research handler argument parsing.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,7 +10,8 @@
 - **Refactor: Cache Directory**: Extracted `ResearchCache::cache_dir()` as the canonical source for the skrills-tome cache path, replacing duplicated logic in the server crate.
 - **Refactor: Knowledge Graph Timestamps**: Changed `Node.created_at` from `String` to `OffsetDateTime` with RFC 3339 serde, ensuring type-safe timestamp handling.
 - **Refactor: Enum Helpers**: Added `NodeKind::all()` and `EdgeKind::all()` for exhaustive enumeration, used by schema sync tests.
-- **Testing**: Added `cache_dir_creates_directory`, `node_kind_all_covers_every_variant`, and `edge_kind_all_covers_every_variant` tests in the tome crate.
+- **Fix: Snake-Case Tool Aliases**: All 9 research MCP tools now accept both kebab-case (`search-papers`) and snake_case (`search_papers`) names for cross-client compatibility.
+- **Testing**: Added `cache_dir_creates_directory`, `node_kind_all_covers_every_variant`, and `edge_kind_all_covers_every_variant` tests in the tome crate. Added `snake_case_aliases_route_sync_research_tools` and `snake_case_aliases_accepted_for_all_sync_research_tools` handler dispatch tests.
 
 ## 0.7.4 - 2026-04-02
 - **NEW: Research MCP Tools**: 9 tools exposing the `tome` crate over MCP: `search-papers`, `search-discussions`, `resolve-doi`, `fetch-pdf`, `query-knowledge-graph`, `add-knowledge-node`, `link-knowledge`, `track-citations`, and `resolve-contradiction` (27 → 36 tools total).

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 0.7.5 - 2026-04-07
+- **Fix: Cursor Skill Descriptions**: Cursor adapter now preserves skill `description` as a plain-text first line instead of discarding it. Handles YAML block scalars (`>-`, `>`, `|-`, `|`), multi-line quoted strings, and strips surrounding quotes. `model_hint` remains as an HTML comment. Cursor shows the description as the skill subtitle instead of `<!-- model_hint: ... -->`.
 - **Refactor: Research Handlers**: Hoisted function-level imports to module scope in `research.rs`, reducing per-call overhead and improving readability.
 - **Refactor: Serde-Based Parsing**: Replaced manual `match` arms for `NodeKind`, `EdgeKind`, and `Parameter` parsing with `serde_json::from_value`, eliminating duplication between enum definitions and parsers.
 - **Fix: Search Papers Error Reporting**: `search_papers_tool` now sets `is_error: true` when all sources fail, instead of silently returning an empty result.

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,11 +7,12 @@
 - **Fix: Discussion Limit Clamping**: `search_discussions_tool` clamps the `limit` parameter to 100 to prevent excessive API requests.
 - **Fix: PDF Download Hardening**: `fetch_pdf_tool` adds a 30-second timeout and HTTP status check before writing downloaded PDFs.
 - **Fix: Unpaywall Error Logging**: `resolve_doi_tool` logs Unpaywall lookup failures via `tracing::warn` instead of silently swallowing errors.
-- **Refactor: Cache Directory**: Extracted `ResearchCache::cache_dir()` as the canonical source for the skrills-tome cache path, replacing duplicated logic in the server crate.
+- **Refactor: Cache Directory**: Extracted `ResearchCache::cache_dir()` as the canonical source for the skrills-tome cache path. Both `open()` and server-side `tome_cache_dir()` now delegate to it.
 - **Refactor: Knowledge Graph Timestamps**: Changed `Node.created_at` from `String` to `OffsetDateTime` with RFC 3339 serde, ensuring type-safe timestamp handling.
 - **Refactor: Enum Helpers**: Added `NodeKind::all()` and `EdgeKind::all()` for exhaustive enumeration, used by schema sync tests.
-- **Fix: Snake-Case Tool Aliases**: All 9 research MCP tools now accept both kebab-case (`search-papers`) and snake_case (`search_papers`) names for cross-client compatibility.
-- **Testing**: Added `cache_dir_creates_directory`, `node_kind_all_covers_every_variant`, and `edge_kind_all_covers_every_variant` tests in the tome crate. Added `snake_case_aliases_route_sync_research_tools` and `snake_case_aliases_accepted_for_all_sync_research_tools` handler dispatch tests.
+- **Fix: Snake-Case Tool Names**: All 36 MCP tools now accept both kebab-case (`search-papers`) and snake_case (`search_papers`) names via universal `replace('_', "-")` normalization in `call_tool()` dispatch.
+- **Fix: Legacy Timestamp Fallback**: `parse_rfc3339` falls back to SQLite's `datetime('now')` format (`YYYY-MM-DD HH:MM:SS`) for knowledge graph databases created before 0.7.5, treating legacy timestamps as UTC.
+- **Testing**: Added `cache_dir_creates_directory`, `node_kind_all_covers_every_variant`, `edge_kind_all_covers_every_variant`, `parse_rfc3339_accepts_legacy_sqlite_format`, and `parse_rfc3339_accepts_rfc3339_format` tests.
 
 ## 0.7.4 - 2026-04-02
 - **NEW: Research MCP Tools**: 9 tools exposing the `tome` crate over MCP: `search-papers`, `search-discussions`, `resolve-doi`, `fetch-pdf`, `query-knowledge-graph`, `add-knowledge-node`, `link-knowledge`, `track-citations`, and `resolve-contradiction` (27 → 36 tools total).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -29,6 +29,7 @@ graph TD
     server --> subagents[subagents]
     server --> dashboard[dashboard<br/>TUI + browser UI]
     server --> metrics[metrics<br/>SQLite telemetry]
+    server --> tome[tome<br/>research APIs, caching]
     sync --> validate
     analyze --> validate
     analyze --> discovery
@@ -41,6 +42,7 @@ graph TD
         validate
         metrics
         dashboard
+        tome
     end
 ```
 
@@ -59,6 +61,8 @@ graph TD
 | `subagents` | Multi-backend agent runtime |
 | `dashboard` | TUI and browser-based skill visualization (Leptos SSR) |
 | `metrics` | SQLite-based telemetry for invocations, validations, sync |
+| `tome` | Research API orchestration, knowledge graph, citation tracking, caching |
+| `test-utils` | Shared test infrastructure (fixtures, RAII guards, temp dirs) |
 
 ## Design Principles
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -76,6 +76,7 @@ The `app` module is split to stay under the 2500 LOC threshold (ADR-0001):
 |--------|-------|---------|
 | `mod.rs` | ~1600 | Core SkillService, MCP handlers, resource serving |
 | `intelligence.rs` | ~740 | Intelligence tool implementations |
+| `research.rs` | ~610 | Research API tool handlers (tome crate integration) |
 
 **LOC Monitoring**: When `app/mod.rs` approaches 2000 lines, extract the next logical group (e.g., subagent tool handlers or resource-serving methods).
 

--- a/docs/tutorials/mcp.md
+++ b/docs/tutorials/mcp.md
@@ -158,8 +158,8 @@ Use ReadMcpResourceTool with server="skrills" and uri="skill://skrills/claude/my
 
 Run `skrills serve --list-tools` to see all available tools.
 
-All research tools accept both kebab-case (`search-papers`) and
-snake_case (`search_papers`) names for cross-client compatibility.
+All tools accept both kebab-case (`search-papers`) and snake_case
+(`search_papers`) names for cross-client compatibility.
 
 ### Sync Tools (11)
 

--- a/docs/tutorials/mcp.md
+++ b/docs/tutorials/mcp.md
@@ -6,12 +6,13 @@ This tutorial shows how to use Skrills as an MCP server with Claude Code CLI and
 
 ## Overview
 
-Skrills runs as an MCP (Model Context Protocol) server, providing 24 tools for skill management:
+Skrills runs as an MCP (Model Context Protocol) server, providing 36 tools for skill management and research:
 
-- **Sync Tools**: Bidirectional sync between Claude, Codex, and Copilot
+- **Sync Tools**: Bidirectional sync between Claude, Codex, Copilot, and Cursor
 - **Validation Tools**: Validate skills for CLI compatibility
 - **Intelligence Tools**: Smart recommendations, project analysis, skill creation
 - **Trace Tools**: Skill loading instrumentation and debugging
+- **Research Tools**: Academic paper search, knowledge graphs, citations, TRIZ
 
 ## Setup
 
@@ -153,17 +154,22 @@ Use ListMcpResourcesTool with server="skrills"
 Use ReadMcpResourceTool with server="skrills" and uri="skill://skrills/claude/my-skill"
 ```
 
-## Available MCP Tools (24 Total)
+## Available MCP Tools (36 Total)
 
-Run `skrills serve --list-tools` to see all available tools:
+Run `skrills serve --list-tools` to see all available tools.
 
-### Sync Tools (9)
+All research tools accept both kebab-case (`search-papers`) and
+snake_case (`search_papers`) names for cross-client compatibility.
+
+### Sync Tools (11)
 
 | Tool | Description |
 |------|-------------|
 | `sync-from-claude` | Copy skills from ~/.claude to ~/.codex |
 | `sync-from-copilot` | Sync from GitHub Copilot CLI |
+| `sync-from-cursor` | Sync from Cursor IDE |
 | `sync-to-copilot` | Sync to GitHub Copilot CLI |
+| `sync-to-cursor` | Sync to Cursor IDE |
 | `sync-skills` | Sync SKILL.md files between agents |
 | `sync-commands` | Sync slash commands |
 | `sync-mcp-servers` | Sync MCP server configurations |
@@ -171,12 +177,13 @@ Run `skrills serve --list-tools` to see all available tools:
 | `sync-all` | Sync everything |
 | `sync-status` | Preview sync changes (dry run) |
 
-### Validation Tools (2)
+### Validation Tools (3)
 
 | Tool | Description |
 |------|-------------|
 | `validate-skills` | Validate for Claude/Codex/Copilot/Cursor compatibility |
 | `analyze-skills` | Analyze token usage and optimization |
+| `search-skills-fuzzy` | Typo-tolerant skill search |
 
 ### Intelligence Tools (6)
 
@@ -187,7 +194,6 @@ Run `skrills serve --list-tools` to see all available tools:
 | `analyze-project-context` | Analyze project languages/frameworks |
 | `suggest-new-skills` | Identify gaps in skill library |
 | `create-skill` | Create skill via GitHub/LLM |
-| `search-skills-fuzzy` | Typo-tolerant skill search |
 | `search-skills-github` | Search GitHub for skills |
 
 ### Trace Tools (4)
@@ -199,12 +205,27 @@ Run `skrills serve --list-tools` to see all available tools:
 | `disable-skill-trace` | Remove trace skills |
 | `skill-loading-selftest` | Confirm skills are loading |
 
-### Other Tools (2)
+### Research Tools (9)
+
+| Tool | Description |
+|------|-------------|
+| `search-papers` | Search arXiv, Semantic Scholar, and OpenAlex |
+| `search-discussions` | Search Hacker News via Algolia |
+| `resolve-doi` | Resolve DOI metadata via CrossRef + Unpaywall |
+| `fetch-pdf` | Download and cache a paper's PDF |
+| `query-knowledge-graph` | Query nodes, edges, and stats |
+| `add-knowledge-node` | Add a node (topic, paper, implementation, discussion) |
+| `link-knowledge` | Create a typed edge between two nodes |
+| `track-citations` | Track, query forward/backward citations |
+| `resolve-contradiction` | TRIZ contradiction matrix lookup |
+
+### Other Tools (3)
 
 | Tool | Description |
 |------|-------------|
 | `resolve-dependencies` | Get transitive dependencies/dependents |
 | `skill-metrics` | Aggregate skill statistics |
+| `get-context-stats` | MCP gateway context statistics |
 
 ## Verifying MCP Connection
 

--- a/plugins/skrills/.claude-plugin/plugin.json
+++ b/plugins/skrills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skrills",
-  "version": "0.7.4",
+  "version": "0.7.5",
   "description": "Skill synchronization and management for Claude Code, Codex, GitHub Copilot, and Cursor. Provides 36 MCP tools for validation, sync, intelligence, research, and tracing.",
   "author": {
     "name": "skrills",

--- a/plugins/skrills/.claude-plugin/plugin.json
+++ b/plugins/skrills/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "skrills",
   "version": "0.7.4",
-  "description": "Skill synchronization and management for Claude Code, Codex, GitHub Copilot, and Cursor. Provides 27 MCP tools for validation, sync, intelligence, and tracing.",
+  "description": "Skill synchronization and management for Claude Code, Codex, GitHub Copilot, and Cursor. Provides 36 MCP tools for validation, sync, intelligence, research, and tracing.",
   "author": {
     "name": "skrills",
     "url": "https://github.com/athola/skrills"

--- a/skrills-portal.html
+++ b/skrills-portal.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en" data-version="0.7.2">
+<html lang="en" data-version="0.7.5">
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<meta name="version" content="0.7.2">
+<meta name="version" content="0.7.5">
 <title>Skrills - Skills Support Engine</title>
 <style>
 :root, html[data-theme="dark"] {
@@ -850,12 +850,12 @@ body {
 <div class="header">
   <div class="header-left">
     <h1>Skrills <span>Portal</span></h1>
-    <span class="version-badge">v0.7.2</span>
+    <span class="version-badge">v0.7.5</span>
   </div>
   <div class="header-stats">
     <span><span class="connection-dot" id="conn-dot"></span><span id="conn-label">Standalone</span></span>
     <span>Skills: <strong id="stat-skills">0</strong></span>
-    <span>Tools: <strong>27</strong></span>
+    <span>Tools: <strong>36</strong></span>
     <span>CLIs: <strong>4</strong></span>
     <button id="theme-toggle" title="Toggle theme" style="background: var(--bg-card); border: 1px solid var(--border); color: var(--text-muted); border-radius: 6px; padding: 0.25rem 0.5rem; font-size: 0.7rem; font-weight: 500; cursor: pointer; font-family: var(--font); transition: border-color 0.15s, color 0.15s;">System</button>
   </div>
@@ -1275,7 +1275,7 @@ Skill instructions..."></textarea>
 
 <!-- Status Bar -->
 <div class="status-bar">
-  <span>Skrills v0.7.3</span>
+  <span>Skrills v0.7.5</span>
   <span>MIT License</span>
   <span id="status-mode">Mode: Standalone</span>
   <span style="margin-left: auto;"><a href="https://github.com/athola/skrills" target="_blank" rel="noopener">GitHub</a></span>


### PR DESCRIPTION
## Summary

- **#199**: Migrate `Node.created_at` from `String` to `OffsetDateTime` with RFC 3339 serde
- **#200**: Add test coverage for T1 (search-by-query), T4 (track-citations schema), T5 (all edge/node kinds), plus snake-case alias dispatch tests
- **#201**: Replace manual enum match arms with `serde_json::from_value` for `NodeKind`, `EdgeKind`, and `Parameter`; add `::all()` methods
- **#202**: Expose `ResearchCache::cache_dir()` as public API; server delegates to it

### Additional hardening
- Snake-case tool aliases for all 9 research MCP tools (cross-client compat)
- Search discussion limit clamped to 100
- PDF download: 30s timeout + HTTP status validation
- Unpaywall errors logged via `tracing::warn`
- Module-level import hoisting in research handlers

### Documentation (commit 3/3)
- README: added "Why Skrills?" value-prop, tightened features, folded Skill Management into Quickstart
- MCP tutorial: expanded from 24 to 36 tools with research tools table
- Portal: version 0.7.2/0.7.3 → 0.7.5, tool count 27 → 36
- Changelogs: snake-case alias fix + handler dispatch tests

## Test plan
- 2022 tests pass (`cargo test --workspace --all-features`)
- Pre-commit hooks pass (fmt, clippy, markdownlint, full suite)
- All 20 README link targets verified
- No stale version references

Fixes #199, fixes #200, fixes #201, fixes #202