### PR TITLE
feat(sync): plugin asset sync, research refactors, and Cursor fixes (0.7.6)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4249,7 +4249,7 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "skrills"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "scopeguard",
@@ -4260,7 +4260,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-analyze"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "parking_lot",
  "regex",
@@ -4277,7 +4277,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-dashboard"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "crossterm",
@@ -4297,7 +4297,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-discovery"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "blake2",
@@ -4314,7 +4314,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-intelligence"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "chrono",
@@ -4336,7 +4336,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-metrics"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4352,7 +4352,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-server"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "axum 0.8.8",
@@ -4410,7 +4410,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-state"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4422,7 +4422,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-subagents"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4449,7 +4449,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-tome"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4468,7 +4468,7 @@ dependencies = [
 
 [[package]]
 name = "skrills-validate"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "proptest",
@@ -4483,7 +4483,7 @@ dependencies = [
 
 [[package]]
 name = "skrills_sync"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "anyhow",
  "dirs",
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "skrills_test_utils"
-version = "0.7.5"
+version = "0.7.6"
 dependencies = [
  "tempfile",
 ]

--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ and Cursor.
 [FAQ](docs/FAQ.md) |
 [Changelog](book/src/changelog.md)
 
-> **What's new in 0.7.5** -- Serde-based enum parsing for research
-> handlers, `OffsetDateTime` timestamps in the knowledge graph, and
-> hardened error reporting across MCP tools.
+> **What's new in 0.7.6** -- Plugin assets sync mirrors runtime
+> scripts, binaries, and source packages from the Claude plugin cache
+> to Cursor. Hash-based change detection and executable permission
+> preservation on Unix.
 > See [changelog](book/src/changelog.md).
 
 ## Why Skrills?
@@ -35,8 +36,9 @@ Skrills validates, analyzes, and syncs skills across four CLI
 environments from a single Rust binary:
 
 - **One-command sync** -- `skrills sync-all` mirrors skills,
-  commands, agents, MCP servers, rules, and preferences between
-  Claude Code, Codex CLI, Copilot CLI, and Cursor.
+  commands, agents, MCP servers, hooks, rules, preferences, and
+  plugin assets between Claude Code, Codex CLI, Copilot CLI,
+  and Cursor.
 - **Validation with autofix** -- detects missing frontmatter,
   incompatible fields, and body issues across each target's
   requirements, then fixes them with `--autofix`.
@@ -66,7 +68,7 @@ setup.
 - **Cross-CLI validation** -- validates against Claude Code
   (permissive), Codex CLI (strict), Copilot CLI (strict), and
   Cursor rules. Auto-derives missing YAML frontmatter.
-- **Multi-directional sync** -- syncs seven asset types across
+- **Multi-directional sync** -- syncs eight asset types across
   four CLIs. File hashing preserves manual edits.
 - **Token analytics** -- per-skill token counts with reduction
   suggestions for context-window management.
@@ -80,6 +82,9 @@ setup.
   validation status, usage metrics, and MCP server configs.
   The standalone [`skrills-portal.html`](skrills-portal.html)
   works offline without a running server.
+- **Plugin asset sync** -- mirrors runtime scripts, binaries,
+  and source packages from the Claude plugin cache to Cursor
+  with hash-based change detection.
 - **Discovery deduplication** -- frontmatter identity matching
   consolidates duplicate skill installations.
 
@@ -132,7 +137,7 @@ skill lifecycle management (`skill-deprecate`, `skill-rollback`,
 
 ## Supported Environments
 
-Skrills syncs seven asset types across four CLI environments.
+Skrills syncs eight asset types across four CLI environments.
 Each cell reflects what the adapter reads and writes today:
 
 | Asset | Claude Code | Codex CLI | Copilot CLI | Cursor |
@@ -144,6 +149,11 @@ Each cell reflects what the adapter reads and writes today:
 | Hooks | Y | -- | -- | Y |
 | Instructions / Rules | Y | -- | Y | Y |
 | Preferences | Y | Y | Y | -- |
+| Plugin Assets | Y | -- | -- | Y |
+
+Plugin assets (scripts, binaries, libraries) are mirrored from the
+Claude plugin cache to `~/.cursor/plugins/cache/`, preserving the
+directory hierarchy so that skills can reference companion scripts.
 
 Cursor rules (`.mdc` files) are mapped bidirectionally via mode
 derivation (`alwaysApply`, glob-scoped, agent-requested).

--- a/book/src/changelog.md
+++ b/book/src/changelog.md
@@ -4,7 +4,7 @@
 
 - **NEW: Plugin Assets Sync**: Cursor sync now mirrors plugin runtime scripts, binaries, and source packages from `~/.claude/plugins/cache/` to `~/.cursor/plugins/cache/`. Preserves directory hierarchy so skills can reference companion scripts at the same relative paths.
 - **NEW: `PluginAsset` Type**: Sync schema type with publisher, plugin name, version, relative path, content, hash, and executable permission tracking.
-- **NEW: Claude Adapter `read_plugin_assets()`**: Walks the plugin cache collecting files from `scripts/`, `bin/`, `hooks/`, `src/`, and config files.
+- **NEW: Claude Adapter `read_plugin_assets()`**: Walks the plugin cache collecting all files except those handled by other sync paths (`skills/`, `commands/`, `agents/`) and runtime artifacts.
 - **NEW: Cursor Adapter `write_plugin_assets()`**: Writes plugin assets with hash-based change detection and executable permission preservation.
 - **Testing**: 18 new tests covering plugin asset read/write, exclusion rules, version picking, executable detection, and integration flows.
 

--- a/book/src/changelog.md
+++ b/book/src/changelog.md
@@ -1,5 +1,13 @@
 # Changelog Highlights
 
+## 0.7.6 (2026-04-12)
+
+- **NEW: Plugin Assets Sync**: Cursor sync now mirrors plugin runtime scripts, binaries, and source packages from `~/.claude/plugins/cache/` to `~/.cursor/plugins/cache/`. Preserves directory hierarchy so skills can reference companion scripts at the same relative paths.
+- **NEW: `PluginAsset` Type**: Sync schema type with publisher, plugin name, version, relative path, content, hash, and executable permission tracking.
+- **NEW: Claude Adapter `read_plugin_assets()`**: Walks the plugin cache collecting files from `scripts/`, `bin/`, `hooks/`, `src/`, and config files.
+- **NEW: Cursor Adapter `write_plugin_assets()`**: Writes plugin assets with hash-based change detection and executable permission preservation.
+- **Testing**: 18 new tests covering plugin asset read/write, exclusion rules, version picking, executable detection, and integration flows.
+
 ## 0.7.5 (2026-04-07)
 
 - **Refactor: Research Handlers**: Serde-based enum parsing, module-level imports, and hardened error handling for research MCP tools.

--- a/crates/analyze/Cargo.toml
+++ b/crates/analyze/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-analyze"
-version = "0.7.5"
+version = "0.7.6"
 edition.workspace = true
 description = "Skill analysis: token counting, dependencies, and optimization"
 license = "MIT"
@@ -19,8 +19,8 @@ walkdir = { workspace = true }
 thiserror = { workspace = true }
 semver = { workspace = true }
 tracing = { workspace = true }
-skrills-validate = { path = "../validate", version = "0.7.5" }
-skrills-discovery = { path = "../discovery", version = "0.7.5" }
+skrills-validate = { path = "../validate", version = "0.7.6" }
+skrills-discovery = { path = "../discovery", version = "0.7.6" }
 parking_lot = { workspace = true }
 
 [dev-dependencies]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 description = "A command-line interface and MCP server for managing local SKILL.md files."
 license = "MIT"
@@ -19,7 +19,7 @@ subagents = ["skrills-server/subagents"]
 http-transport = ["skrills-server/http-transport"]
 
 [dependencies]
-skrills-server = { path = "../server", version = "0.7.5" }
+skrills-server = { path = "../server", version = "0.7.6" }
 anyhow.workspace = true
 
 [dev-dependencies]

--- a/crates/dashboard/Cargo.toml
+++ b/crates/dashboard/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-dashboard"
-version = "0.7.5"
+version = "0.7.6"
 edition.workspace = true
 description = "Terminal UI dashboard for skrills metrics and monitoring"
 license = "MIT"
@@ -13,9 +13,9 @@ categories = ["development-tools", "visualization"]
 publish = true
 
 [dependencies]
-skrills-metrics = { path = "../metrics", version = "0.7.5" }
-skrills-discovery = { path = "../discovery", version = "0.7.5" }
-skrills_sync = { path = "../sync", version = "0.7.5" }
+skrills-metrics = { path = "../metrics", version = "0.7.6" }
+skrills-discovery = { path = "../discovery", version = "0.7.6" }
+skrills_sync = { path = "../sync", version = "0.7.6" }
 
 # TUI
 ratatui = "0.30"

--- a/crates/discovery/Cargo.toml
+++ b/crates/discovery/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-discovery"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 description = "Filesystem discovery and hashing utilities used by the skrills MCP server."
 license = "MIT"

--- a/crates/intelligence/Cargo.toml
+++ b/crates/intelligence/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-intelligence"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 description = "Intelligent skill recommendations based on usage patterns and project context."
 license = "MIT"

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-metrics"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 description = "SQLite-based metrics collection for skrills skill invocations, validations, and sync events."
 license = "MIT"

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-server"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 description = "Core library for the skrills MCP server: discovery, filtering, manifest generation, and runtime control."
 license = "MIT"
@@ -45,18 +45,18 @@ rcgen = { version = "0.14", optional = true }
 x509-parser = { version = "0.18", optional = true }
 time.workspace = true
 
-skrills-subagents = { path = "../subagents", version = "0.7.5", optional = true }
+skrills-subagents = { path = "../subagents", version = "0.7.6", optional = true }
 
-skrills-discovery = { path = "../discovery", version = "0.7.5" }
-skrills-state = { path = "../state", version = "0.7.5" }
-skrills_sync = { path = "../sync", version = "0.7.5" }
-skrills-validate = { path = "../validate", version = "0.7.5" }
-skrills-analyze = { path = "../analyze", version = "0.7.5" }
-skrills-intelligence = { path = "../intelligence", version = "0.7.5" }
-skrills-metrics = { path = "../metrics", version = "0.7.5" }
-skrills-tome = { path = "../tome", version = "0.7.5" }
+skrills-discovery = { path = "../discovery", version = "0.7.6" }
+skrills-state = { path = "../state", version = "0.7.6" }
+skrills_sync = { path = "../sync", version = "0.7.6" }
+skrills-validate = { path = "../validate", version = "0.7.6" }
+skrills-analyze = { path = "../analyze", version = "0.7.6" }
+skrills-intelligence = { path = "../intelligence", version = "0.7.6" }
+skrills-metrics = { path = "../metrics", version = "0.7.6" }
+skrills-tome = { path = "../tome", version = "0.7.6" }
 reqwest = { version = "0.13", default-features = false, features = ["rustls"] }
-skrills-dashboard = { path = "../dashboard", version = "0.7.5", optional = true }
+skrills-dashboard = { path = "../dashboard", version = "0.7.6", optional = true }
 shellexpand = "3"
 regex = "1"
 sha2.workspace = true

--- a/crates/server/src/app/tools.rs
+++ b/crates/server/src/app/tools.rs
@@ -1077,6 +1077,7 @@ impl SkillService {
             sync_skills: true,
             sync_agents: true,
             sync_instructions: true,
+            sync_plugin_assets: true, // Sync plugin scripts/binaries
             ..Default::default()
         };
 

--- a/crates/state/Cargo.toml
+++ b/crates/state/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-state"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 description = "State management for skrills runtime options, pins, and persisted overrides."
 license = "MIT"

--- a/crates/subagents/Cargo.toml
+++ b/crates/subagents/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-subagents"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 description = "Subagent MCP tools for the skrills server with pluggable backends."
 license = "MIT"
@@ -28,8 +28,8 @@ thiserror.workspace = true
 tempfile.workspace = true
 toml.workspace = true
 
-skrills-discovery = { path = "../discovery", version = "0.7.5" }
-skrills-state = { path = "../state", version = "0.7.5" }
+skrills-discovery = { path = "../discovery", version = "0.7.6" }
+skrills-state = { path = "../state", version = "0.7.6" }
 
 [dev-dependencies]
 wiremock = "0.6"

--- a/crates/sync/Cargo.toml
+++ b/crates/sync/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills_sync"
-version = "0.7.5"
+version = "0.7.6"
 edition.workspace = true
 description = "Preference synchronization and validation sync utilities for skrills"
 license = "MIT"
@@ -20,7 +20,7 @@ sha2.workspace = true
 walkdir.workspace = true
 dirs.workspace = true
 tracing.workspace = true
-skrills-validate = { path = "../validate", version = "0.7.5" }
+skrills-validate = { path = "../validate", version = "0.7.6" }
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/sync/src/adapters/claude.rs
+++ b/crates/sync/src/adapters/claude.rs
@@ -2,7 +2,9 @@
 
 use super::traits::{AgentAdapter, FieldSupport};
 use super::utils::{collect_module_files, hash_content, is_hidden_path, sanitize_name};
-use crate::common::{Command, ContentFormat, McpServer, McpTransport, ModuleFile, Preferences};
+use crate::common::{
+    Command, ContentFormat, McpServer, McpTransport, ModuleFile, PluginAsset, Preferences,
+};
 use crate::report::{SkipReason, WriteReport};
 use crate::Result;
 use anyhow::Context;
@@ -129,6 +131,7 @@ impl AgentAdapter for ClaudeAdapter {
             hooks: true,
             agents: true,
             instructions: true,
+            plugin_assets: true,
         }
     }
 
@@ -1002,6 +1005,158 @@ impl AgentAdapter for ClaudeAdapter {
 
         Ok(report)
     }
+
+    fn read_plugin_assets(&self) -> Result<Vec<PluginAsset>> {
+        let cache_dir = self.root.join("plugins/cache");
+        if !cache_dir.exists() {
+            return Ok(vec![]);
+        }
+
+        // Directories already handled by other sync paths
+        const SYNCED_DIRS: &[&str] = &["skills", "commands", "agents"];
+        // Directories to skip (not needed at runtime)
+        const SKIP_DIRS: &[&str] = &[
+            "tests",
+            ".venv",
+            "__pycache__",
+            "node_modules",
+            ".git",
+            ".claude-plugin",
+            ".cursor-plugin",
+        ];
+
+        let mut assets = Vec::new();
+
+        // Walk: cache/<marketplace>/<plugin>/<version>/
+        for marketplace_entry in fs::read_dir(&cache_dir)? {
+            let marketplace_entry = marketplace_entry?;
+            let marketplace_path = marketplace_entry.path();
+            if !marketplace_path.is_dir() {
+                continue;
+            }
+            let publisher = marketplace_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or("unknown")
+                .to_string();
+
+            for plugin_entry in fs::read_dir(&marketplace_path)? {
+                let plugin_entry = plugin_entry?;
+                let plugin_path = plugin_entry.path();
+                if !plugin_path.is_dir() {
+                    continue;
+                }
+                let plugin_name = plugin_path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("unknown")
+                    .to_string();
+
+                // Find the latest version directory
+                let mut versions: Vec<_> = fs::read_dir(&plugin_path)?
+                    .filter_map(|e| e.ok())
+                    .filter(|e| e.path().is_dir())
+                    .collect();
+                versions.sort_by_key(|e| {
+                    e.metadata()
+                        .and_then(|m| m.modified())
+                        .unwrap_or(SystemTime::UNIX_EPOCH)
+                });
+                let version_entry = match versions.last() {
+                    Some(e) => e,
+                    None => continue,
+                };
+                let version_path = version_entry.path();
+                let version = version_path
+                    .file_name()
+                    .and_then(|n| n.to_str())
+                    .unwrap_or("0.0.0")
+                    .to_string();
+
+                // Walk the version directory collecting asset files
+                for entry in WalkDir::new(&version_path)
+                    .min_depth(1)
+                    .max_depth(10)
+                    .follow_links(false)
+                {
+                    let entry = match entry {
+                        Ok(e) => e,
+                        Err(_) => continue,
+                    };
+                    let path = entry.path();
+
+                    if !path.is_file() {
+                        continue;
+                    }
+
+                    let rel_path = match path.strip_prefix(&version_path) {
+                        Ok(p) => p,
+                        Err(_) => continue,
+                    };
+
+                    // Skip hidden files
+                    if is_hidden_path(rel_path) {
+                        continue;
+                    }
+
+                    // Check if this file is under a synced or skipped directory
+                    let top_component = rel_path
+                        .components()
+                        .next()
+                        .and_then(|c| c.as_os_str().to_str())
+                        .unwrap_or("");
+
+                    if SYNCED_DIRS.contains(&top_component) {
+                        continue; // Already synced by skills/commands/agents
+                    }
+                    if SKIP_DIRS.contains(&top_component) {
+                        continue;
+                    }
+                    // Also check any ancestor for skip dirs (e.g., nested __pycache__)
+                    if rel_path.components().any(|c| {
+                        c.as_os_str()
+                            .to_str()
+                            .is_some_and(|s| SKIP_DIRS.contains(&s))
+                    }) {
+                        continue;
+                    }
+
+                    let content = match fs::read(path) {
+                        Ok(c) => c,
+                        Err(_) => continue,
+                    };
+
+                    let executable = {
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::fs::PermissionsExt;
+                            fs::metadata(path)
+                                .map(|m| m.permissions().mode() & 0o111 != 0)
+                                .unwrap_or(false)
+                        }
+                        #[cfg(not(unix))]
+                        {
+                            false
+                        }
+                    };
+
+                    let hash = hash_content(&content);
+
+                    assets.push(PluginAsset {
+                        plugin_name: plugin_name.clone(),
+                        publisher: publisher.clone(),
+                        version: version.clone(),
+                        relative_path: rel_path.to_path_buf(),
+                        content,
+                        hash,
+                        executable,
+                    });
+                }
+            }
+        }
+
+        Ok(assets)
+    }
 }
 
 #[cfg(test)]
@@ -1599,5 +1754,192 @@ mod tests {
         // Empty tool configs should not appear in JSON output
         assert!(server_json.get("allowedTools").is_none());
         assert!(server_json.get("disabledTools").is_none());
+    }
+
+    #[test]
+    fn read_plugin_assets_finds_scripts() {
+        let tmp = tempdir().unwrap();
+        let plugin_dir = tmp
+            .path()
+            .join("plugins/cache/market/myplugin/1.0.0/scripts");
+        fs::create_dir_all(&plugin_dir).unwrap();
+        fs::write(plugin_dir.join("tool.py"), b"# tool\n").unwrap();
+
+        let adapter = ClaudeAdapter::with_root(tmp.path().to_path_buf());
+        let assets = adapter.read_plugin_assets().unwrap();
+
+        assert_eq!(assets.len(), 1, "Should find one asset: {:?}", assets);
+        assert_eq!(assets[0].plugin_name, "myplugin");
+        assert_eq!(assets[0].publisher, "market");
+        assert_eq!(assets[0].version, "1.0.0");
+        assert_eq!(
+            assets[0].relative_path,
+            std::path::PathBuf::from("scripts/tool.py")
+        );
+    }
+
+    #[test]
+    fn read_plugin_assets_excludes_skills_and_tests() {
+        let tmp = tempdir().unwrap();
+        let base = tmp.path().join("plugins/cache/market/plug/1.0.0");
+
+        // Script (should be included)
+        let scripts = base.join("scripts");
+        fs::create_dir_all(&scripts).unwrap();
+        fs::write(scripts.join("run.py"), b"# run\n").unwrap();
+
+        // Skill (should be excluded)
+        let skills = base.join("skills/my-skill");
+        fs::create_dir_all(&skills).unwrap();
+        fs::write(skills.join("SKILL.md"), b"# Skill\n").unwrap();
+
+        // Tests (should be excluded)
+        let tests = base.join("tests");
+        fs::create_dir_all(&tests).unwrap();
+        fs::write(tests.join("test_run.py"), b"# test\n").unwrap();
+
+        let adapter = ClaudeAdapter::with_root(tmp.path().to_path_buf());
+        let assets = adapter.read_plugin_assets().unwrap();
+
+        assert_eq!(assets.len(), 1, "Should only find the script");
+        assert_eq!(
+            assets[0].relative_path,
+            std::path::PathBuf::from("scripts/run.py")
+        );
+    }
+
+    #[test]
+    fn read_plugin_assets_picks_latest_version() {
+        // GIVEN a plugin with two version directories
+        let tmp = tempdir().unwrap();
+        let old_ver = tmp.path().join("plugins/cache/market/plug/1.0.0/scripts");
+        let new_ver = tmp.path().join("plugins/cache/market/plug/2.0.0/scripts");
+        fs::create_dir_all(&old_ver).unwrap();
+        fs::create_dir_all(&new_ver).unwrap();
+        fs::write(old_ver.join("old.py"), b"# old\n").unwrap();
+
+        // Ensure 2.0.0 has a newer mtime by writing after 1.0.0
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        fs::write(new_ver.join("new.py"), b"# new\n").unwrap();
+
+        // WHEN reading plugin assets
+        let adapter = ClaudeAdapter::with_root(tmp.path().to_path_buf());
+        let assets = adapter.read_plugin_assets().unwrap();
+
+        // THEN only the latest version's files are returned
+        assert_eq!(assets.len(), 1, "Should only scan latest version");
+        assert_eq!(assets[0].version, "2.0.0");
+        assert_eq!(
+            assets[0].relative_path,
+            std::path::PathBuf::from("scripts/new.py")
+        );
+    }
+
+    #[test]
+    fn read_plugin_assets_skips_hidden_files() {
+        // GIVEN a plugin with a hidden file alongside a normal file
+        let tmp = tempdir().unwrap();
+        let scripts = tmp.path().join("plugins/cache/market/plug/1.0.0/scripts");
+        fs::create_dir_all(&scripts).unwrap();
+        fs::write(scripts.join("visible.py"), b"# ok\n").unwrap();
+        fs::write(scripts.join(".hidden.py"), b"# hidden\n").unwrap();
+
+        // WHEN reading plugin assets
+        let adapter = ClaudeAdapter::with_root(tmp.path().to_path_buf());
+        let assets = adapter.read_plugin_assets().unwrap();
+
+        // THEN hidden files are excluded
+        assert_eq!(assets.len(), 1);
+        assert_eq!(
+            assets[0].relative_path,
+            std::path::PathBuf::from("scripts/visible.py")
+        );
+    }
+
+    #[test]
+    fn read_plugin_assets_includes_config_files() {
+        // GIVEN a plugin with non-script config files
+        let tmp = tempdir().unwrap();
+        let base = tmp.path().join("plugins/cache/market/plug/1.0.0");
+        fs::create_dir_all(&base).unwrap();
+        fs::write(base.join("pyproject.toml"), b"[project]\n").unwrap();
+        fs::write(base.join("Makefile"), b"all:\n\techo ok\n").unwrap();
+
+        // WHEN reading plugin assets
+        let adapter = ClaudeAdapter::with_root(tmp.path().to_path_buf());
+        let assets = adapter.read_plugin_assets().unwrap();
+
+        // THEN config files at the plugin root are included
+        assert_eq!(assets.len(), 2);
+        let paths: HashSet<String> = assets
+            .iter()
+            .map(|a| a.relative_path.display().to_string())
+            .collect();
+        assert!(paths.contains("pyproject.toml"));
+        assert!(paths.contains("Makefile"));
+    }
+
+    #[test]
+    fn read_plugin_assets_empty_when_only_excluded_dirs() {
+        // GIVEN a plugin that only has excluded directories
+        let tmp = tempdir().unwrap();
+        let base = tmp.path().join("plugins/cache/market/plug/1.0.0");
+        let skills = base.join("skills/my-skill");
+        let tests = base.join("tests");
+        let commands = base.join("commands");
+        fs::create_dir_all(&skills).unwrap();
+        fs::create_dir_all(&tests).unwrap();
+        fs::create_dir_all(&commands).unwrap();
+        fs::write(skills.join("SKILL.md"), b"# Skill\n").unwrap();
+        fs::write(tests.join("test.py"), b"# test\n").unwrap();
+        fs::write(commands.join("cmd.md"), b"# cmd\n").unwrap();
+
+        // WHEN reading plugin assets
+        let adapter = ClaudeAdapter::with_root(tmp.path().to_path_buf());
+        let assets = adapter.read_plugin_assets().unwrap();
+
+        // THEN no assets are returned
+        assert!(
+            assets.is_empty(),
+            "All dirs are excluded, expected 0 assets"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_plugin_assets_detects_executable_permission() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // GIVEN a plugin with an executable script and a non-executable file
+        let tmp = tempdir().unwrap();
+        let scripts = tmp.path().join("plugins/cache/market/plug/1.0.0/scripts");
+        fs::create_dir_all(&scripts).unwrap();
+
+        let exec_path = scripts.join("run.sh");
+        fs::write(&exec_path, b"#!/bin/sh\necho ok\n").unwrap();
+        fs::set_permissions(&exec_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let data_path = scripts.join("config.json");
+        fs::write(&data_path, b"{}").unwrap();
+        fs::set_permissions(&data_path, fs::Permissions::from_mode(0o644)).unwrap();
+
+        // WHEN reading plugin assets
+        let adapter = ClaudeAdapter::with_root(tmp.path().to_path_buf());
+        let assets = adapter.read_plugin_assets().unwrap();
+
+        // THEN the executable flag is set correctly
+        assert_eq!(assets.len(), 2);
+        let exec_asset = assets.iter().find(|a| a.relative_path.ends_with("run.sh"));
+        let data_asset = assets
+            .iter()
+            .find(|a| a.relative_path.ends_with("config.json"));
+        assert!(
+            exec_asset.unwrap().executable,
+            "run.sh should be marked executable"
+        );
+        assert!(
+            !data_asset.unwrap().executable,
+            "config.json should not be marked executable"
+        );
     }
 }

--- a/crates/sync/src/adapters/claude.rs
+++ b/crates/sync/src/adapters/claude.rs
@@ -14,6 +14,22 @@ use std::path::PathBuf;
 use std::time::SystemTime;
 use walkdir::WalkDir;
 
+/// Parse a directory entry name as a semver-ish tuple `(major, minor, patch)`.
+///
+/// Falls back to `(0, 0, 0)` for non-semver names so they sort before any real version.
+fn semver_tuple(entry: &fs::DirEntry) -> (u64, u64, u64) {
+    let name = entry
+        .file_name()
+        .to_str()
+        .unwrap_or("")
+        .to_string();
+    let parts: Vec<&str> = name.split('.').collect();
+    let major = parts.first().and_then(|s| s.parse().ok()).unwrap_or(0u64);
+    let minor = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0u64);
+    let patch = parts.get(2).and_then(|s| s.parse().ok()).unwrap_or(0u64);
+    (major, minor, patch)
+}
+
 /// Adapter for Claude Code configuration.
 pub struct ClaudeAdapter {
     root: PathBuf,
@@ -1034,11 +1050,16 @@ impl AgentAdapter for ClaudeAdapter {
             if !marketplace_path.is_dir() {
                 continue;
             }
-            let publisher = marketplace_path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("unknown")
-                .to_string();
+            let publisher = match marketplace_path.file_name().and_then(|n| n.to_str()) {
+                Some(name) => name.to_string(),
+                None => {
+                    tracing::warn!(
+                        path = %marketplace_path.display(),
+                        "Skipping non-UTF-8 marketplace directory"
+                    );
+                    continue;
+                }
+            };
 
             for plugin_entry in fs::read_dir(&marketplace_path)? {
                 let plugin_entry = plugin_entry?;
@@ -1046,32 +1067,52 @@ impl AgentAdapter for ClaudeAdapter {
                 if !plugin_path.is_dir() {
                     continue;
                 }
-                let plugin_name = plugin_path
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("unknown")
-                    .to_string();
+                let plugin_name = match plugin_path.file_name().and_then(|n| n.to_str()) {
+                    Some(name) => name.to_string(),
+                    None => {
+                        tracing::warn!(
+                            path = %plugin_path.display(),
+                            "Skipping non-UTF-8 plugin directory"
+                        );
+                        continue;
+                    }
+                };
 
-                // Find the latest version directory
+                // Find the latest version directory (prefer semver, fall back to mtime)
                 let mut versions: Vec<_> = fs::read_dir(&plugin_path)?
-                    .filter_map(|e| e.ok())
+                    .filter_map(|e| match e {
+                        Ok(entry) => Some(entry),
+                        Err(err) => {
+                            tracing::warn!(
+                                plugin = %plugin_name,
+                                error = %err,
+                                "Failed to read version directory entry"
+                            );
+                            None
+                        }
+                    })
                     .filter(|e| e.path().is_dir())
                     .collect();
-                versions.sort_by_key(|e| {
-                    e.metadata()
-                        .and_then(|m| m.modified())
-                        .unwrap_or(SystemTime::UNIX_EPOCH)
+                versions.sort_by(|a, b| {
+                    let ver_a = semver_tuple(a);
+                    let ver_b = semver_tuple(b);
+                    ver_a.cmp(&ver_b)
                 });
                 let version_entry = match versions.last() {
                     Some(e) => e,
                     None => continue,
                 };
                 let version_path = version_entry.path();
-                let version = version_path
-                    .file_name()
-                    .and_then(|n| n.to_str())
-                    .unwrap_or("0.0.0")
-                    .to_string();
+                let version = match version_path.file_name().and_then(|n| n.to_str()) {
+                    Some(name) => name.to_string(),
+                    None => {
+                        tracing::warn!(
+                            path = %version_path.display(),
+                            "Skipping non-UTF-8 version directory"
+                        );
+                        continue;
+                    }
+                };
 
                 // Walk the version directory collecting asset files
                 for entry in WalkDir::new(&version_path)
@@ -1081,7 +1122,14 @@ impl AgentAdapter for ClaudeAdapter {
                 {
                     let entry = match entry {
                         Ok(e) => e,
-                        Err(_) => continue,
+                        Err(e) => {
+                            tracing::warn!(
+                                plugin = %plugin_name,
+                                error = %e,
+                                "Failed to read directory entry while scanning plugin assets"
+                            );
+                            continue;
+                        }
                     };
                     let path = entry.path();
 
@@ -1123,7 +1171,15 @@ impl AgentAdapter for ClaudeAdapter {
 
                     let content = match fs::read(path) {
                         Ok(c) => c,
-                        Err(_) => continue,
+                        Err(e) => {
+                            tracing::warn!(
+                                path = %path.display(),
+                                plugin = %plugin_name,
+                                error = %e,
+                                "Failed to read plugin asset file, skipping"
+                            );
+                            continue;
+                        }
                     };
 
                     let executable = {
@@ -1140,17 +1196,14 @@ impl AgentAdapter for ClaudeAdapter {
                         }
                     };
 
-                    let hash = hash_content(&content);
-
-                    assets.push(PluginAsset {
-                        plugin_name: plugin_name.clone(),
-                        publisher: publisher.clone(),
-                        version: version.clone(),
-                        relative_path: rel_path.to_path_buf(),
+                    assets.push(PluginAsset::new(
+                        plugin_name.clone(),
+                        publisher.clone(),
+                        version.clone(),
+                        rel_path.to_path_buf(),
                         content,
-                        hash,
                         executable,
-                    });
+                    ));
                 }
             }
         }
@@ -1810,16 +1863,13 @@ mod tests {
 
     #[test]
     fn read_plugin_assets_picks_latest_version() {
-        // GIVEN a plugin with two version directories
+        // GIVEN a plugin with two version directories (semver-sorted)
         let tmp = tempdir().unwrap();
         let old_ver = tmp.path().join("plugins/cache/market/plug/1.0.0/scripts");
         let new_ver = tmp.path().join("plugins/cache/market/plug/2.0.0/scripts");
         fs::create_dir_all(&old_ver).unwrap();
         fs::create_dir_all(&new_ver).unwrap();
         fs::write(old_ver.join("old.py"), b"# old\n").unwrap();
-
-        // Ensure 2.0.0 has a newer mtime by writing after 1.0.0
-        std::thread::sleep(std::time::Duration::from_millis(10));
         fs::write(new_ver.join("new.py"), b"# new\n").unwrap();
 
         // WHEN reading plugin assets

--- a/crates/sync/src/adapters/claude.rs
+++ b/crates/sync/src/adapters/claude.rs
@@ -18,11 +18,7 @@ use walkdir::WalkDir;
 ///
 /// Falls back to `(0, 0, 0)` for non-semver names so they sort before any real version.
 fn semver_tuple(entry: &fs::DirEntry) -> (u64, u64, u64) {
-    let name = entry
-        .file_name()
-        .to_str()
-        .unwrap_or("")
-        .to_string();
+    let name = entry.file_name().to_str().unwrap_or("").to_string();
     let parts: Vec<&str> = name.split('.').collect();
     let major = parts.first().and_then(|s| s.parse().ok()).unwrap_or(0u64);
     let minor = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0u64);

--- a/crates/sync/src/adapters/codex.rs
+++ b/crates/sync/src/adapters/codex.rs
@@ -170,9 +170,10 @@ impl AgentAdapter for CodexAdapter {
             mcp_servers: true,
             preferences: true,
             skills: true,
-            hooks: false,        // Codex doesn't support hooks
-            agents: false,       // Codex doesn't read agents, but write_agents converts to skills
-            instructions: false, // Codex doesn't support instructions
+            hooks: false,         // Codex doesn't support hooks
+            agents: false,        // Codex doesn't read agents, but write_agents converts to skills
+            instructions: false,  // Codex doesn't support instructions
+            plugin_assets: false, // Codex doesn't support plugin assets
         }
     }
 

--- a/crates/sync/src/adapters/copilot/mod.rs
+++ b/crates/sync/src/adapters/copilot/mod.rs
@@ -82,9 +82,10 @@ impl AgentAdapter for CopilotAdapter {
             mcp_servers: true,
             preferences: true,
             skills: true,
-            hooks: false,       // Copilot doesn't support hooks
-            agents: true,       // Copilot supports custom agents in ~/.copilot/agents/
-            instructions: true, // Copilot supports *.instructions.md files
+            hooks: false,         // Copilot doesn't support hooks
+            agents: true,         // Copilot supports custom agents in ~/.copilot/agents/
+            instructions: true,   // Copilot supports *.instructions.md files
+            plugin_assets: false, // Copilot doesn't support plugin assets
         }
     }
 

--- a/crates/sync/src/adapters/cursor/mod.rs
+++ b/crates/sync/src/adapters/cursor/mod.rs
@@ -12,9 +12,10 @@
 //!   `alwaysApply`) in `.cursor/rules/`. No other adapter writes this format.
 //! - **Hooks**: Cursor supports 18+ lifecycle events (camelCase) vs Claude's 8
 //!   (PascalCase). Event name mapping is handled in the hooks module.
-//! - **Skills**: Cursor skills have no frontmatter — Claude frontmatter is stripped
-//!   on write and absent on read. **This is lossy**: a Claude→Cursor→Claude
-//!   roundtrip loses all frontmatter metadata (name, description, dependencies).
+//! - **Skills**: Cursor skills have no YAML frontmatter — Claude frontmatter is stripped
+//!   on write, but `description` is preserved as a plain-text first line and `model_hint`
+//!   as an HTML comment. **Partially lossy**: a Claude→Cursor→Claude roundtrip loses
+//!   most frontmatter metadata (name, dependencies, version, tags).
 //! - **Agents**: Field translation: `background` ↔ `is_background`, model name
 //!   mapping, `tools`/`isolation` dropped (Cursor-only: `readonly`).
 //! - **Commands**: Near-identical to Claude format (`.cursor/commands/*.md`).
@@ -167,18 +168,37 @@ impl AgentAdapter for CursorAdapter {
                 .join(&asset.version);
             let target_path = target_dir.join(&asset.relative_path);
 
-            // Path containment check
+            // Path containment check — security: prevent path traversal
             if !crate::adapters::utils::is_path_contained(&target_path, &cache_dir) {
-                debug!(
+                tracing::warn!(
+                    plugin = %asset.plugin_name,
                     path = %asset.relative_path.display(),
-                    "Skipping plugin asset with path outside cache directory"
+                    "Rejected plugin asset with path outside cache directory"
                 );
+                report.skipped.push(SkipReason::Unchanged {
+                    item: format!(
+                        "BLOCKED:{}/{}:{}",
+                        asset.plugin_name,
+                        asset.version,
+                        asset.relative_path.display()
+                    ),
+                });
                 continue;
             }
 
             // Check if unchanged
             if target_path.exists() {
-                let existing = fs::read(&target_path).unwrap_or_default();
+                let existing = match fs::read(&target_path) {
+                    Ok(data) => data,
+                    Err(e) => {
+                        tracing::debug!(
+                            path = %target_path.display(),
+                            error = %e,
+                            "Could not read existing asset for hash comparison, will re-write"
+                        );
+                        vec![]
+                    }
+                };
                 if crate::adapters::utils::hash_content(&existing) == asset.hash {
                     report.skipped.push(SkipReason::Unchanged {
                         item: format!(

--- a/crates/sync/src/adapters/cursor/mod.rs
+++ b/crates/sync/src/adapters/cursor/mod.rs
@@ -33,7 +33,7 @@ pub(crate) mod utils;
 mod tests;
 
 use super::traits::{AgentAdapter, FieldSupport};
-use crate::common::{Command, McpServer, Preferences};
+use crate::common::{Command, McpServer, PluginAsset, Preferences};
 use crate::report::WriteReport;
 use crate::Result;
 use std::collections::HashMap;
@@ -75,7 +75,8 @@ impl AgentAdapter for CursorAdapter {
             skills: true,
             hooks: true,
             agents: true,
-            instructions: true, // Rules (.mdc) mapped via instructions
+            instructions: true,  // Rules (.mdc) mapped via instructions
+            plugin_assets: true, // Cursor mirrors Claude's plugin cache
         }
     }
 
@@ -141,5 +142,80 @@ impl AgentAdapter for CursorAdapter {
 
     fn write_instructions(&self, instructions: &[Command]) -> Result<WriteReport> {
         rules::write_rules(&self.root, instructions)
+    }
+
+    fn write_plugin_assets(&self, assets: &[PluginAsset]) -> Result<WriteReport> {
+        use crate::report::SkipReason;
+        use std::fs;
+        use tracing::debug;
+
+        let mut report = WriteReport::default();
+
+        if assets.is_empty() {
+            return Ok(report);
+        }
+
+        let cache_dir = self.root.join("plugins").join("cache");
+        // Create cache dir upfront so is_path_contained can canonicalize it
+        fs::create_dir_all(&cache_dir)?;
+
+        for asset in assets {
+            // Mirror Claude's cache structure: plugins/cache/<publisher>/<plugin>/<version>/
+            let target_dir = cache_dir
+                .join(&asset.publisher)
+                .join(&asset.plugin_name)
+                .join(&asset.version);
+            let target_path = target_dir.join(&asset.relative_path);
+
+            // Path containment check
+            if !crate::adapters::utils::is_path_contained(&target_path, &cache_dir) {
+                debug!(
+                    path = %asset.relative_path.display(),
+                    "Skipping plugin asset with path outside cache directory"
+                );
+                continue;
+            }
+
+            // Check if unchanged
+            if target_path.exists() {
+                let existing = fs::read(&target_path).unwrap_or_default();
+                if crate::adapters::utils::hash_content(&existing) == asset.hash {
+                    report.skipped.push(SkipReason::Unchanged {
+                        item: format!(
+                            "{}/{}:{}",
+                            asset.plugin_name,
+                            asset.version,
+                            asset.relative_path.display()
+                        ),
+                    });
+                    continue;
+                }
+            }
+
+            // Ensure parent directory exists
+            if let Some(parent) = target_path.parent() {
+                fs::create_dir_all(parent)?;
+            }
+
+            // Write the file
+            fs::write(&target_path, &asset.content)?;
+
+            // Preserve executable permissions
+            #[cfg(unix)]
+            if asset.executable {
+                use std::os::unix::fs::PermissionsExt;
+                let perms = std::fs::Permissions::from_mode(0o755);
+                fs::set_permissions(&target_path, perms)?;
+            }
+
+            debug!(
+                plugin = %asset.plugin_name,
+                path = %asset.relative_path.display(),
+                "Wrote plugin asset to Cursor"
+            );
+            report.written += 1;
+        }
+
+        Ok(report)
     }
 }

--- a/crates/sync/src/adapters/cursor/tests.rs
+++ b/crates/sync/src/adapters/cursor/tests.rs
@@ -1076,7 +1076,11 @@ fn plugin_assets_path_traversal_blocked() {
 
     // The traversal asset should be blocked (counted as skipped), normal one written
     assert_eq!(report.written, 1, "Only the safe asset should be written");
-    assert_eq!(report.skipped.len(), 1, "The traversal asset should be skipped");
+    assert_eq!(
+        report.skipped.len(),
+        1,
+        "The traversal asset should be skipped"
+    );
 
     // Verify the malicious file was NOT created outside the cache
     assert!(
@@ -1085,6 +1089,8 @@ fn plugin_assets_path_traversal_blocked() {
     );
 
     // Verify the normal file WAS created
-    let expected = tmp.path().join("plugins/cache/legit-market/good-plugin/1.0.0/scripts/helper.py");
+    let expected = tmp
+        .path()
+        .join("plugins/cache/legit-market/good-plugin/1.0.0/scripts/helper.py");
     assert!(expected.exists(), "Normal asset should be written");
 }

--- a/crates/sync/src/adapters/cursor/tests.rs
+++ b/crates/sync/src/adapters/cursor/tests.rs
@@ -779,3 +779,312 @@ fn mcp_empty_tool_configs_omitted_from_json() {
     assert!(server_json.get("allowedTools").is_none());
     assert!(server_json.get("disabledTools").is_none());
 }
+
+// --- MCP edge cases ---
+
+#[test]
+fn mcp_http_transport_detected() {
+    let tmp = TempDir::new().unwrap();
+    let mcp_path = tmp.path().join("mcp.json");
+    std::fs::write(
+        &mcp_path,
+        r#"{
+        "mcpServers": {
+            "remote-server": {
+                "url": "https://mcp.example.com/v1",
+                "headers": {"Authorization": "Bearer tok"}
+            }
+        }
+    }"#,
+    )
+    .unwrap();
+
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+    let servers = adapter.read_mcp_servers().unwrap();
+    let server = servers.get("remote-server").unwrap();
+    assert_eq!(server.transport, McpTransport::Http);
+    assert_eq!(server.url.as_deref(), Some("https://mcp.example.com/v1"));
+    assert!(
+        server.command.is_empty(),
+        "HTTP server should have no command"
+    );
+}
+
+#[test]
+fn mcp_skips_entries_without_command_or_url() {
+    let tmp = TempDir::new().unwrap();
+    let mcp_path = tmp.path().join("mcp.json");
+    std::fs::write(
+        &mcp_path,
+        r#"{
+        "mcpServers": {
+            "broken": {"args": ["--verbose"]},
+            "valid": {"command": "/usr/bin/server"}
+        }
+    }"#,
+    )
+    .unwrap();
+
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+    let servers = adapter.read_mcp_servers().unwrap();
+    assert_eq!(servers.len(), 1, "broken entry should be skipped");
+    assert!(servers.contains_key("valid"));
+}
+
+#[test]
+fn mcp_disabled_server_preserved() {
+    let tmp = TempDir::new().unwrap();
+    let mcp_path = tmp.path().join("mcp.json");
+    std::fs::write(
+        &mcp_path,
+        r#"{
+        "mcpServers": {
+            "dormant": {
+                "command": "/usr/bin/server",
+                "enabled": false
+            }
+        }
+    }"#,
+    )
+    .unwrap();
+
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+    let servers = adapter.read_mcp_servers().unwrap();
+    let server = servers.get("dormant").unwrap();
+    assert!(!server.enabled, "disabled flag should be preserved");
+}
+
+#[test]
+fn mcp_skip_unchanged_on_second_write() {
+    let tmp = TempDir::new().unwrap();
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+
+    let mut servers = HashMap::new();
+    servers.insert(
+        "stable".to_string(),
+        McpServer {
+            name: "stable".to_string(),
+            transport: McpTransport::Stdio,
+            command: "/usr/bin/server".to_string(),
+            args: vec![],
+            env: HashMap::new(),
+            url: None,
+            headers: None,
+            enabled: true,
+            allowed_tools: vec![],
+            disabled_tools: vec![],
+        },
+    );
+
+    let first = adapter.write_mcp_servers(&servers).unwrap();
+    assert_eq!(first.written, 1);
+
+    let second = adapter.write_mcp_servers(&servers).unwrap();
+    assert_eq!(second.written, 0, "unchanged MCP config should be skipped");
+    assert_eq!(second.skipped.len(), 1);
+}
+
+#[test]
+fn mcp_empty_servers_returns_empty_report() {
+    let tmp = TempDir::new().unwrap();
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+    let servers = HashMap::new();
+    let report = adapter.write_mcp_servers(&servers).unwrap();
+    assert_eq!(report.written, 0);
+    assert!(report.skipped.is_empty());
+}
+
+#[test]
+fn mcp_nonexistent_file_returns_empty() {
+    let tmp = TempDir::new().unwrap();
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+    let servers = adapter.read_mcp_servers().unwrap();
+    assert!(servers.is_empty());
+}
+
+// --- Commands edge cases ---
+
+#[test]
+fn commands_hidden_files_skipped() {
+    let tmp = TempDir::new().unwrap();
+    let cmd_dir = tmp.path().join("commands");
+    std::fs::create_dir_all(&cmd_dir).unwrap();
+
+    std::fs::write(cmd_dir.join("visible.md"), "# Visible\n").unwrap();
+    std::fs::write(cmd_dir.join(".hidden.md"), "# Hidden\n").unwrap();
+
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+    let commands = adapter.read_commands(false).unwrap();
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].name, "visible");
+}
+
+#[test]
+fn commands_non_md_files_skipped() {
+    let tmp = TempDir::new().unwrap();
+    let cmd_dir = tmp.path().join("commands");
+    std::fs::create_dir_all(&cmd_dir).unwrap();
+
+    std::fs::write(cmd_dir.join("real.md"), "# Real\n").unwrap();
+    std::fs::write(cmd_dir.join("config.json"), "{}").unwrap();
+    std::fs::write(cmd_dir.join("script.sh"), "#!/bin/bash\n").unwrap();
+
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+    let commands = adapter.read_commands(false).unwrap();
+    assert_eq!(commands.len(), 1);
+    assert_eq!(commands[0].name, "real");
+}
+
+#[test]
+fn commands_empty_list_writes_nothing() {
+    let tmp = TempDir::new().unwrap();
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+    let report = adapter.write_commands(&[]).unwrap();
+    assert_eq!(report.written, 0);
+    // commands dir should not be created for empty writes
+    assert!(!tmp.path().join("commands").exists());
+}
+
+#[test]
+fn commands_subdirectories_ignored() {
+    let tmp = TempDir::new().unwrap();
+    let cmd_dir = tmp.path().join("commands");
+    std::fs::create_dir_all(cmd_dir.join("subdir")).unwrap();
+    std::fs::write(cmd_dir.join("subdir/nested.md"), "# Nested\n").unwrap();
+    std::fs::write(cmd_dir.join("top-level.md"), "# Top Level\n").unwrap();
+
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+    let commands = adapter.read_commands(false).unwrap();
+    assert_eq!(commands.len(), 1, "subdirectories should be skipped");
+    assert_eq!(commands[0].name, "top-level");
+}
+
+#[test]
+fn commands_frontmatter_stripped_on_write() {
+    let tmp = TempDir::new().unwrap();
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+
+    let content = "---\nallowed-tools: [Read, Write]\ndescription: Test command\n---\n\n# Do Thing\n\nCommand body.\n";
+    let commands = vec![make_command("with-fm", content)];
+    adapter.write_commands(&commands).unwrap();
+
+    let read_back = adapter.read_commands(false).unwrap();
+    let body = String::from_utf8_lossy(&read_back[0].content);
+    assert!(
+        !body.contains("---"),
+        "Frontmatter should be stripped from commands"
+    );
+    assert!(body.contains("# Do Thing"), "Body should be preserved");
+}
+
+// --- Paths unit tests ---
+
+#[test]
+fn paths_all_resolve_under_root() {
+    let root = std::path::Path::new("/tmp/fake-cursor");
+    assert_eq!(paths::skills_dir(root), root.join("skills"));
+    assert_eq!(paths::commands_dir(root), root.join("commands"));
+    assert_eq!(paths::agents_dir(root), root.join("agents"));
+    assert_eq!(paths::rules_dir(root), root.join("rules"));
+    assert_eq!(paths::hooks_path(root), root.join("hooks.json"));
+    assert_eq!(paths::mcp_config_path(root), root.join("mcp.json"));
+}
+
+// --- Skills edge cases ---
+
+#[test]
+fn skills_empty_list_writes_nothing() {
+    let tmp = TempDir::new().unwrap();
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+    let report = adapter.write_skills(&[]).unwrap();
+    assert_eq!(report.written, 0);
+    assert!(!tmp.path().join("skills").exists());
+}
+
+#[test]
+fn skills_directories_without_skill_md_skipped() {
+    let tmp = TempDir::new().unwrap();
+    let skills_dir = tmp.path().join("skills");
+
+    // Directory with SKILL.md
+    std::fs::create_dir_all(skills_dir.join("valid-skill")).unwrap();
+    std::fs::write(skills_dir.join("valid-skill/SKILL.md"), "# Valid Skill\n").unwrap();
+
+    // Directory without SKILL.md (just loose files)
+    std::fs::create_dir_all(skills_dir.join("no-skill-md")).unwrap();
+    std::fs::write(skills_dir.join("no-skill-md/README.md"), "# Not a skill\n").unwrap();
+
+    // Regular file at skills root (not a directory)
+    std::fs::write(skills_dir.join("stray-file.md"), "# Stray\n").unwrap();
+
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+    let skills = adapter.read_skills().unwrap();
+    assert_eq!(
+        skills.len(),
+        1,
+        "only directories with SKILL.md should be read"
+    );
+    assert_eq!(skills[0].name, "valid-skill");
+}
+
+#[test]
+fn skills_model_hint_injected_as_comment() {
+    let tmp = TempDir::new().unwrap();
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+
+    let content =
+        "---\nname: smart-skill\nmodel_hint: opus\n---\n\n# Smart Skill\n\nDo things smartly.\n";
+    let skills = vec![make_command("smart-skill", content)];
+    adapter.write_skills(&skills).unwrap();
+
+    let read_back = adapter.read_skills().unwrap();
+    let body = String::from_utf8_lossy(&read_back[0].content);
+    assert!(
+        body.contains("<!-- model_hint: opus -->"),
+        "model_hint should be injected as HTML comment, got: {}",
+        body
+    );
+}
+
+// --- Plugin Asset Security Tests ---
+
+#[test]
+fn plugin_assets_path_traversal_blocked() {
+    use crate::common::PluginAsset;
+
+    let tmp = TempDir::new().unwrap();
+    let adapter = CursorAdapter::with_root(tmp.path().to_path_buf());
+
+    let malicious = PluginAsset::new(
+        "evil-plugin".to_string(),
+        "shady-market".to_string(),
+        "1.0.0".to_string(),
+        std::path::PathBuf::from("../../etc/passwd"),
+        b"root:x:0:0:root:/root:/bin/bash\n".to_vec(),
+        false,
+    );
+    let normal = PluginAsset::new(
+        "good-plugin".to_string(),
+        "legit-market".to_string(),
+        "1.0.0".to_string(),
+        std::path::PathBuf::from("scripts/helper.py"),
+        b"# helper\n".to_vec(),
+        false,
+    );
+
+    let report = adapter.write_plugin_assets(&[malicious, normal]).unwrap();
+
+    // The traversal asset should be blocked (counted as skipped), normal one written
+    assert_eq!(report.written, 1, "Only the safe asset should be written");
+    assert_eq!(report.skipped.len(), 1, "The traversal asset should be skipped");
+
+    // Verify the malicious file was NOT created outside the cache
+    assert!(
+        !tmp.path().join("etc/passwd").exists(),
+        "Path traversal must not create files outside cache"
+    );
+
+    // Verify the normal file WAS created
+    let expected = tmp.path().join("plugins/cache/legit-market/good-plugin/1.0.0/scripts/helper.py");
+    assert!(expected.exists(), "Normal asset should be written");
+}

--- a/crates/sync/src/adapters/traits.rs
+++ b/crates/sync/src/adapters/traits.rs
@@ -1,6 +1,6 @@
 //! Trait definition for agent adapters.
 
-use crate::common::{Command, CommonConfig, McpServer, Preferences};
+use crate::common::{Command, CommonConfig, McpServer, PluginAsset, Preferences};
 use crate::report::WriteReport;
 use crate::Result;
 use std::collections::HashMap;
@@ -16,6 +16,7 @@ pub struct FieldSupport {
     pub hooks: bool,
     pub agents: bool,
     pub instructions: bool,
+    pub plugin_assets: bool,
 }
 
 #[cfg(test)]
@@ -56,6 +57,14 @@ pub trait AgentAdapter: Send + Sync {
     /// Read instructions from native format (e.g., CLAUDE.md, *.instructions.md)
     fn read_instructions(&self) -> Result<Vec<Command>>;
 
+    /// Read plugin assets (scripts, binaries, libraries) from plugin cache.
+    ///
+    /// Default implementation returns empty — only adapters with a plugin cache
+    /// (like Claude) need to override this.
+    fn read_plugin_assets(&self) -> Result<Vec<PluginAsset>> {
+        Ok(vec![])
+    }
+
     /// Read complete configuration
     fn read_all(&self) -> Result<CommonConfig> {
         Ok(CommonConfig {
@@ -66,6 +75,7 @@ pub trait AgentAdapter: Send + Sync {
             hooks: self.read_hooks()?,
             agents: self.read_agents()?,
             instructions: self.read_instructions()?,
+            plugin_assets: self.read_plugin_assets()?,
         })
     }
 
@@ -91,6 +101,15 @@ pub trait AgentAdapter: Send + Sync {
 
     /// Write instructions to native format (e.g., CLAUDE.md, *.instructions.md)
     fn write_instructions(&self, instructions: &[Command]) -> Result<WriteReport>;
+
+    /// Write plugin assets (scripts, binaries, libraries) to target location.
+    ///
+    /// Default implementation is a no-op — only adapters that support plugin
+    /// assets (like Cursor, which mirrors the Claude plugin cache) need to
+    /// override this.
+    fn write_plugin_assets(&self, _assets: &[PluginAsset]) -> Result<WriteReport> {
+        Ok(WriteReport::default())
+    }
 }
 
 /// Blanket impl so `Box<dyn AgentAdapter>` can be used with `SyncOrchestrator`.
@@ -125,6 +144,9 @@ impl AgentAdapter for Box<dyn AgentAdapter> {
     fn read_instructions(&self) -> Result<Vec<Command>> {
         (**self).read_instructions()
     }
+    fn read_plugin_assets(&self) -> Result<Vec<PluginAsset>> {
+        (**self).read_plugin_assets()
+    }
     fn write_commands(&self, commands: &[Command]) -> Result<WriteReport> {
         (**self).write_commands(commands)
     }
@@ -145,5 +167,8 @@ impl AgentAdapter for Box<dyn AgentAdapter> {
     }
     fn write_instructions(&self, instructions: &[Command]) -> Result<WriteReport> {
         (**self).write_instructions(instructions)
+    }
+    fn write_plugin_assets(&self, assets: &[PluginAsset]) -> Result<WriteReport> {
+        (**self).write_plugin_assets(assets)
     }
 }

--- a/crates/sync/src/common.rs
+++ b/crates/sync/src/common.rs
@@ -23,10 +23,33 @@ pub struct PluginAsset {
     pub relative_path: PathBuf,
     /// File content as bytes
     pub content: Vec<u8>,
-    /// SHA256 hash for change detection
+    /// SHA256 hash of `content` for change detection (auto-computed by `new()`)
     pub hash: String,
     /// Whether the file should be executable
     pub executable: bool,
+}
+
+impl PluginAsset {
+    /// Creates a new `PluginAsset`, auto-computing the SHA256 hash from `content`.
+    pub fn new(
+        plugin_name: String,
+        publisher: String,
+        version: String,
+        relative_path: PathBuf,
+        content: Vec<u8>,
+        executable: bool,
+    ) -> Self {
+        let hash = crate::adapters::utils::hash_content(&content);
+        Self {
+            plugin_name,
+            publisher,
+            version,
+            relative_path,
+            content,
+            hash,
+            executable,
+        }
+    }
 }
 
 /// A companion file within a skill directory (e.g., helpers, sub-modules).
@@ -208,15 +231,14 @@ mod tests {
 
     #[test]
     fn plugin_asset_serializes_roundtrip() {
-        let asset = PluginAsset {
-            plugin_name: "abstract".to_string(),
-            publisher: "claude-night-market".to_string(),
-            version: "1.8.3".to_string(),
-            relative_path: PathBuf::from("scripts/makefile_dogfooder.py"),
-            content: b"#!/usr/bin/env python3\nprint('hello')\n".to_vec(),
-            hash: "abc123".to_string(),
-            executable: true,
-        };
+        let asset = PluginAsset::new(
+            "abstract".to_string(),
+            "claude-night-market".to_string(),
+            "1.8.3".to_string(),
+            PathBuf::from("scripts/makefile_dogfooder.py"),
+            b"#!/usr/bin/env python3\nprint('hello')\n".to_vec(),
+            true,
+        );
 
         let json = serde_json::to_string(&asset).unwrap();
         let restored: PluginAsset = serde_json::from_str(&json).unwrap();
@@ -229,7 +251,8 @@ mod tests {
             PathBuf::from("scripts/makefile_dogfooder.py")
         );
         assert_eq!(restored.content, asset.content);
-        assert_eq!(restored.hash, "abc123");
+        assert_eq!(restored.hash, asset.hash, "hash should roundtrip");
+        assert!(!restored.hash.is_empty(), "hash should be auto-computed");
         assert!(restored.executable);
     }
 }

--- a/crates/sync/src/common.rs
+++ b/crates/sync/src/common.rs
@@ -5,6 +5,30 @@ use std::collections::HashMap;
 use std::path::PathBuf;
 use std::time::SystemTime;
 
+/// A plugin asset file (script, binary, library) that skills/hooks depend on.
+///
+/// These are files within a plugin directory that aren't handled by other
+/// sync artifact types (skills, commands, agents, hooks config). They include
+/// Python scripts, shell scripts, binary helpers, and source packages that
+/// skills and hooks reference at runtime.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PluginAsset {
+    /// Plugin identifier (e.g., "abstract")
+    pub plugin_name: String,
+    /// Marketplace/publisher (e.g., "claude-night-market")
+    pub publisher: String,
+    /// Version string (e.g., "1.8.3")
+    pub version: String,
+    /// Relative path within the plugin directory (e.g., "scripts/makefile_dogfooder.py")
+    pub relative_path: PathBuf,
+    /// File content as bytes
+    pub content: Vec<u8>,
+    /// SHA256 hash for change detection
+    pub hash: String,
+    /// Whether the file should be executable
+    pub executable: bool,
+}
+
 /// A companion file within a skill directory (e.g., helpers, sub-modules).
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 pub struct ModuleFile {
@@ -142,6 +166,7 @@ pub struct CommonConfig {
     pub hooks: Vec<Command>,
     pub agents: Vec<Command>,
     pub instructions: Vec<Command>,
+    pub plugin_assets: Vec<PluginAsset>,
 }
 
 #[cfg(test)]
@@ -179,5 +204,32 @@ mod tests {
             a.hash, b.hash,
             "different content should produce different hash"
         );
+    }
+
+    #[test]
+    fn plugin_asset_serializes_roundtrip() {
+        let asset = PluginAsset {
+            plugin_name: "abstract".to_string(),
+            publisher: "claude-night-market".to_string(),
+            version: "1.8.3".to_string(),
+            relative_path: PathBuf::from("scripts/makefile_dogfooder.py"),
+            content: b"#!/usr/bin/env python3\nprint('hello')\n".to_vec(),
+            hash: "abc123".to_string(),
+            executable: true,
+        };
+
+        let json = serde_json::to_string(&asset).unwrap();
+        let restored: PluginAsset = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(restored.plugin_name, "abstract");
+        assert_eq!(restored.publisher, "claude-night-market");
+        assert_eq!(restored.version, "1.8.3");
+        assert_eq!(
+            restored.relative_path,
+            PathBuf::from("scripts/makefile_dogfooder.py")
+        );
+        assert_eq!(restored.content, asset.content);
+        assert_eq!(restored.hash, "abc123");
+        assert!(restored.executable);
     }
 }

--- a/crates/sync/src/lib.rs
+++ b/crates/sync/src/lib.rs
@@ -40,6 +40,7 @@
 //!             hooks: false,
 //!             agents: false,
 //!             instructions: false,
+//!             plugin_assets: false,
 //!         }
 //!     }
 //!
@@ -138,7 +139,7 @@ pub mod validation;
 pub use adapters::{
     AgentAdapter, ClaudeAdapter, CodexAdapter, CopilotAdapter, CursorAdapter, FieldSupport,
 };
-pub use common::{Command, CommonConfig, ContentFormat, McpServer, Preferences};
+pub use common::{Command, CommonConfig, ContentFormat, McpServer, PluginAsset, Preferences};
 pub use models::transform_model;
 #[allow(deprecated)]
 pub use orchestrator::{

--- a/crates/sync/src/orchestrator.rs
+++ b/crates/sync/src/orchestrator.rs
@@ -78,6 +78,9 @@ pub struct SyncParams {
     /// Include marketplace content (e.g. uninstalled plugins)
     #[serde(default)]
     pub include_marketplace: bool,
+    /// Sync plugin assets (scripts, binaries, libraries that skills/hooks depend on)
+    #[serde(default = "default_true")]
+    pub sync_plugin_assets: bool,
 }
 
 impl Default for SyncParams {
@@ -96,6 +99,7 @@ impl Default for SyncParams {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: true,
         }
     }
 }
@@ -376,6 +380,23 @@ impl<S: AgentAdapter, T: AgentAdapter> SyncOrchestrator<S, T> {
                 || self.target.read_instructions(),
                 |items| self.target.write_instructions(items),
             )?;
+        }
+
+        // Sync plugin assets (scripts, binaries, libraries)
+        if params.sync_plugin_assets {
+            if !target_support.plugin_assets {
+                tracing::debug!(
+                    target = %self.target.name(),
+                    "Target does not natively support plugin assets; skipping"
+                );
+            } else {
+                let assets = self.source.read_plugin_assets()?;
+                if !params.dry_run {
+                    report.plugin_assets = self.target.write_plugin_assets(&assets)?;
+                } else {
+                    report.plugin_assets.written = assets.len();
+                }
+            }
         }
 
         report.success = true;

--- a/crates/sync/src/report.rs
+++ b/crates/sync/src/report.rs
@@ -177,7 +177,8 @@ impl SyncReport {
             + self.commands.duplicates
             + self.agents.duplicates
             + self.hooks.duplicates
-            + self.instructions.duplicates;
+            + self.instructions.duplicates
+            + self.plugin_assets.duplicates;
         if total_dups > 0 {
             out.push_str(&format!(
                 "\n  ⚠ {} duplicate name(s) detected — first occurrence kept, others dropped.\n    Run with RUST_LOG=warn for details.\n",

--- a/crates/sync/src/report.rs
+++ b/crates/sync/src/report.rs
@@ -105,6 +105,7 @@ pub struct SyncReport {
     pub agents: WriteReport,
     pub hooks: WriteReport,
     pub instructions: WriteReport,
+    pub plugin_assets: WriteReport,
     /// Overall success status
     pub success: bool,
     /// Summary message
@@ -129,6 +130,7 @@ impl SyncReport {
             + self.agents.written
             + self.hooks.written
             + self.instructions.written
+            + self.plugin_assets.written
     }
 
     /// Returns total items skipped across all types.
@@ -140,6 +142,7 @@ impl SyncReport {
             + self.agents.skipped.len()
             + self.hooks.skipped.len()
             + self.instructions.skipped.len()
+            + self.plugin_assets.skipped.len()
     }
 
     /// Generates a formatted summary for display.
@@ -166,6 +169,9 @@ impl SyncReport {
         out.push_str(&line("Agents:", &self.agents));
         out.push_str(&line("Hooks:", &self.hooks));
         out.push_str(&line("Instructions:", &self.instructions));
+        if self.plugin_assets.written > 0 || !self.plugin_assets.skipped.is_empty() {
+            out.push_str(&line("Plugin Assets:", &self.plugin_assets));
+        }
 
         let total_dups = self.skills.duplicates
             + self.commands.duplicates
@@ -530,6 +536,61 @@ mod tests {
             assert_eq!(restored.skills.written, 5);
             assert!(restored.success);
             assert_eq!(restored.summary, "Test summary");
+        }
+    }
+
+    // ==========================================
+    // Plugin Assets in Report Tests
+    // ==========================================
+
+    mod plugin_assets_report {
+        use super::*;
+
+        #[test]
+        fn given_plugin_assets_when_total_synced_then_included_in_sum() {
+            let mut report = SyncReport::new();
+            report.skills.written = 2;
+            report.plugin_assets.written = 5;
+
+            assert_eq!(report.total_synced(), 7);
+        }
+
+        #[test]
+        fn given_plugin_assets_skipped_when_total_skipped_then_included_in_sum() {
+            let mut report = SyncReport::new();
+            report.plugin_assets.skipped = vec![
+                SkipReason::Unchanged {
+                    item: "a".to_string(),
+                },
+                SkipReason::Unchanged {
+                    item: "b".to_string(),
+                },
+            ];
+
+            assert_eq!(report.total_skipped(), 2);
+        }
+
+        #[test]
+        fn given_plugin_assets_written_when_format_summary_then_line_present() {
+            let mut report = SyncReport::new();
+            report.plugin_assets.written = 10;
+
+            let summary = report.format_summary("claude", "cursor");
+            assert!(
+                summary.contains("Plugin Assets"),
+                "Summary should contain Plugin Assets line when there are assets"
+            );
+            assert!(summary.contains("10 synced"));
+        }
+
+        #[test]
+        fn given_no_plugin_assets_when_format_summary_then_line_omitted() {
+            let report = SyncReport::new();
+            let summary = report.format_summary("claude", "cursor");
+            assert!(
+                !summary.contains("Plugin Assets"),
+                "Summary should omit Plugin Assets line when empty"
+            );
         }
     }
 }

--- a/crates/sync/tests/copilot_sync_integration.rs
+++ b/crates/sync/tests/copilot_sync_integration.rs
@@ -206,6 +206,7 @@ mod copilot_to_claude_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -257,6 +258,7 @@ mod copilot_to_claude_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -301,6 +303,7 @@ mod copilot_to_claude_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -349,6 +352,7 @@ mod claude_to_copilot_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -399,6 +403,7 @@ mod claude_to_copilot_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -449,6 +454,7 @@ mod claude_to_copilot_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -501,6 +507,7 @@ mod copilot_to_codex_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -545,6 +552,7 @@ mod copilot_to_codex_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -594,6 +602,7 @@ mod copilot_dry_run_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -867,6 +876,7 @@ This is a test agent for Copilot.
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -937,6 +947,7 @@ This is a test agent for Copilot.
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -990,6 +1001,7 @@ This is a test agent for Copilot.
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -1041,6 +1053,7 @@ This is a test agent for Copilot.
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -1092,6 +1105,7 @@ This is a test agent for Copilot.
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -1147,6 +1161,7 @@ This is a test agent for Copilot.
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);

--- a/crates/sync/tests/cursor_sync_integration.rs
+++ b/crates/sync/tests/cursor_sync_integration.rs
@@ -691,3 +691,329 @@ fn is_valid_platform_recognizes_all() {
     assert!(!is_valid_platform("vscode"));
     assert!(!is_valid_platform(""));
 }
+
+// ========================================================================
+// Plugin Asset Sync Tests
+// ========================================================================
+
+#[test]
+fn plugin_assets_synced_from_claude_to_cursor() {
+    let setup = CursorSyncTestSetup::new().unwrap();
+
+    // Create a mock plugin cache structure in Claude
+    let plugin_dir = setup
+        .claude_dir
+        .path()
+        .join("plugins/cache/claude-night-market/abstract/1.8.3");
+
+    // Create scripts directory with Python files
+    let scripts_dir = plugin_dir.join("scripts");
+    fs::create_dir_all(&scripts_dir).unwrap();
+    fs::write(
+        scripts_dir.join("makefile_dogfooder.py"),
+        b"#!/usr/bin/env python3\nprint('dogfood')\n",
+    )
+    .unwrap();
+    fs::write(
+        scripts_dir.join("validate_plugin.py"),
+        b"#!/usr/bin/env python3\nimport sys\n",
+    )
+    .unwrap();
+
+    // Create hooks directory with Python handlers
+    let hooks_dir = plugin_dir.join("hooks");
+    fs::create_dir_all(&hooks_dir).unwrap();
+    fs::write(
+        hooks_dir.join("session_start.py"),
+        b"#!/usr/bin/env python3\nprint('session started')\n",
+    )
+    .unwrap();
+
+    // Create bin directory
+    let bin_dir = plugin_dir.join("bin");
+    fs::create_dir_all(&bin_dir).unwrap();
+    fs::write(bin_dir.join("fallback.py"), b"# fallback script\n").unwrap();
+
+    // Create src directory (Python package)
+    let src_dir = plugin_dir.join("src/abstract");
+    fs::create_dir_all(&src_dir).unwrap();
+    fs::write(src_dir.join("__init__.py"), b"").unwrap();
+    fs::write(src_dir.join("utils.py"), b"def helper(): pass\n").unwrap();
+
+    // Also create directories that SHOULD be excluded
+    let skills_dir = plugin_dir.join("skills/my-skill");
+    fs::create_dir_all(&skills_dir).unwrap();
+    fs::write(skills_dir.join("SKILL.md"), b"# My Skill\n").unwrap();
+
+    let tests_dir = plugin_dir.join("tests");
+    fs::create_dir_all(&tests_dir).unwrap();
+    fs::write(tests_dir.join("test_something.py"), b"# test\n").unwrap();
+
+    let venv_dir = plugin_dir.join(".venv/lib");
+    fs::create_dir_all(&venv_dir).unwrap();
+    fs::write(venv_dir.join("site.py"), b"# venv\n").unwrap();
+
+    let pycache_dir = plugin_dir.join("scripts/__pycache__");
+    fs::create_dir_all(&pycache_dir).unwrap();
+    fs::write(pycache_dir.join("foo.pyc"), b"\x00\x00").unwrap();
+
+    // Create .claude-plugin metadata (should be excluded)
+    let meta_dir = plugin_dir.join(".claude-plugin");
+    fs::create_dir_all(&meta_dir).unwrap();
+    fs::write(meta_dir.join("plugin.json"), b"{}").unwrap();
+
+    // Sync with plugin assets enabled
+    let source = ClaudeAdapter::with_root(setup.claude_dir.path().to_path_buf());
+    let target = CursorAdapter::with_root(setup.cursor_dir.path().to_path_buf());
+    let orch = SyncOrchestrator::new(source, target);
+
+    let params = SyncParams {
+        sync_skills: false,
+        sync_commands: false,
+        sync_mcp_servers: false,
+        sync_preferences: false,
+        sync_agents: false,
+        sync_hooks: false,
+        sync_instructions: false,
+        sync_plugin_assets: true,
+        ..Default::default()
+    };
+
+    let report = orch.sync(&params).unwrap();
+    assert!(report.success);
+
+    // Verify scripts were synced
+    let cursor_plugin = setup
+        .cursor_dir
+        .path()
+        .join("plugins/cache/claude-night-market/abstract/1.8.3");
+
+    assert!(
+        cursor_plugin.join("scripts/makefile_dogfooder.py").exists(),
+        "makefile_dogfooder.py should be synced"
+    );
+    assert!(
+        cursor_plugin.join("scripts/validate_plugin.py").exists(),
+        "validate_plugin.py should be synced"
+    );
+    assert!(
+        cursor_plugin.join("hooks/session_start.py").exists(),
+        "hook handler should be synced"
+    );
+    assert!(
+        cursor_plugin.join("bin/fallback.py").exists(),
+        "bin script should be synced"
+    );
+    assert!(
+        cursor_plugin.join("src/abstract/__init__.py").exists(),
+        "Python package should be synced"
+    );
+    assert!(
+        cursor_plugin.join("src/abstract/utils.py").exists(),
+        "Python source should be synced"
+    );
+
+    // Verify content is correct
+    let content = fs::read_to_string(cursor_plugin.join("scripts/makefile_dogfooder.py")).unwrap();
+    assert!(content.contains("print('dogfood')"));
+
+    // Verify excluded directories were NOT synced
+    assert!(
+        !cursor_plugin.join("skills").exists(),
+        "skills/ should not be synced as plugin asset"
+    );
+    assert!(
+        !cursor_plugin.join("tests").exists(),
+        "tests/ should not be synced"
+    );
+    assert!(
+        !cursor_plugin.join(".venv").exists(),
+        ".venv/ should not be synced"
+    );
+    assert!(
+        !cursor_plugin.join("scripts/__pycache__").exists(),
+        "__pycache__/ should not be synced"
+    );
+    assert!(
+        !cursor_plugin.join(".claude-plugin").exists(),
+        ".claude-plugin/ should not be synced"
+    );
+
+    // Verify asset count (should have 6 files synced)
+    assert!(
+        report.plugin_assets.written >= 6,
+        "Expected at least 6 plugin assets, got {}",
+        report.plugin_assets.written
+    );
+}
+
+#[test]
+fn plugin_assets_skipped_when_disabled() {
+    let setup = CursorSyncTestSetup::new().unwrap();
+
+    // Create a simple plugin with a script
+    let plugin_dir = setup
+        .claude_dir
+        .path()
+        .join("plugins/cache/market/plugin/1.0.0/scripts");
+    fs::create_dir_all(&plugin_dir).unwrap();
+    fs::write(plugin_dir.join("tool.py"), b"# tool\n").unwrap();
+
+    let source = ClaudeAdapter::with_root(setup.claude_dir.path().to_path_buf());
+    let target = CursorAdapter::with_root(setup.cursor_dir.path().to_path_buf());
+    let orch = SyncOrchestrator::new(source, target);
+
+    let params = SyncParams {
+        sync_plugin_assets: false,
+        ..Default::default()
+    };
+
+    let report = orch.sync(&params).unwrap();
+    assert!(report.success);
+    assert_eq!(
+        report.plugin_assets.written, 0,
+        "No plugin assets should be synced when disabled"
+    );
+}
+
+#[test]
+fn plugin_assets_unchanged_files_skipped() {
+    let setup = CursorSyncTestSetup::new().unwrap();
+
+    // Create plugin with a script
+    let plugin_dir = setup
+        .claude_dir
+        .path()
+        .join("plugins/cache/market/plugin/1.0.0/scripts");
+    fs::create_dir_all(&plugin_dir).unwrap();
+    fs::write(plugin_dir.join("tool.py"), b"# tool\n").unwrap();
+
+    let source = ClaudeAdapter::with_root(setup.claude_dir.path().to_path_buf());
+    let target = CursorAdapter::with_root(setup.cursor_dir.path().to_path_buf());
+
+    let params = SyncParams {
+        sync_skills: false,
+        sync_commands: false,
+        sync_mcp_servers: false,
+        sync_preferences: false,
+        sync_agents: false,
+        sync_hooks: false,
+        sync_instructions: false,
+        sync_plugin_assets: true,
+        ..Default::default()
+    };
+
+    // First sync: should write
+    let orch = SyncOrchestrator::new(source, target);
+    let report1 = orch.sync(&params).unwrap();
+    assert_eq!(report1.plugin_assets.written, 1);
+
+    // Second sync: same content, should skip
+    let source2 = ClaudeAdapter::with_root(setup.claude_dir.path().to_path_buf());
+    let target2 = CursorAdapter::with_root(setup.cursor_dir.path().to_path_buf());
+    let orch2 = SyncOrchestrator::new(source2, target2);
+    let report2 = orch2.sync(&params).unwrap();
+    assert_eq!(
+        report2.plugin_assets.written, 0,
+        "Unchanged files should be skipped"
+    );
+    assert_eq!(report2.plugin_assets.skipped.len(), 1);
+}
+
+#[test]
+fn plugin_assets_empty_cache_returns_no_assets() {
+    let setup = CursorSyncTestSetup::new().unwrap();
+
+    // No plugin cache exists
+    let source = ClaudeAdapter::with_root(setup.claude_dir.path().to_path_buf());
+    let assets = source.read_plugin_assets().unwrap();
+    assert!(assets.is_empty());
+}
+
+#[test]
+fn plugin_assets_preserves_directory_hierarchy() {
+    let setup = CursorSyncTestSetup::new().unwrap();
+
+    // Create nested directory structure
+    let plugin_dir = setup
+        .claude_dir
+        .path()
+        .join("plugins/cache/market/plugin/2.0.0");
+    let nested = plugin_dir.join("scripts/dogfooder");
+    fs::create_dir_all(&nested).unwrap();
+    fs::write(nested.join("validator.py"), b"# validator\n").unwrap();
+    fs::write(nested.join("parser.py"), b"# parser\n").unwrap();
+    fs::write(nested.join("__init__.py"), b"").unwrap();
+
+    let source = ClaudeAdapter::with_root(setup.claude_dir.path().to_path_buf());
+    let target = CursorAdapter::with_root(setup.cursor_dir.path().to_path_buf());
+    let orch = SyncOrchestrator::new(source, target);
+
+    let params = SyncParams {
+        sync_skills: false,
+        sync_commands: false,
+        sync_mcp_servers: false,
+        sync_preferences: false,
+        sync_agents: false,
+        sync_hooks: false,
+        sync_instructions: false,
+        sync_plugin_assets: true,
+        ..Default::default()
+    };
+
+    let report = orch.sync(&params).unwrap();
+    assert!(report.success);
+
+    let cursor_plugin = setup
+        .cursor_dir
+        .path()
+        .join("plugins/cache/market/plugin/2.0.0");
+
+    assert!(cursor_plugin
+        .join("scripts/dogfooder/validator.py")
+        .exists());
+    assert!(cursor_plugin.join("scripts/dogfooder/parser.py").exists());
+    assert!(cursor_plugin.join("scripts/dogfooder/__init__.py").exists());
+}
+
+#[test]
+fn plugin_assets_dry_run_writes_nothing() {
+    let setup = CursorSyncTestSetup::new().unwrap();
+
+    let plugin_dir = setup
+        .claude_dir
+        .path()
+        .join("plugins/cache/market/plugin/1.0.0/scripts");
+    fs::create_dir_all(&plugin_dir).unwrap();
+    fs::write(plugin_dir.join("tool.py"), b"# tool\n").unwrap();
+
+    let source = ClaudeAdapter::with_root(setup.claude_dir.path().to_path_buf());
+    let target = CursorAdapter::with_root(setup.cursor_dir.path().to_path_buf());
+    let orch = SyncOrchestrator::new(source, target);
+
+    let params = SyncParams {
+        dry_run: true,
+        sync_skills: false,
+        sync_commands: false,
+        sync_mcp_servers: false,
+        sync_preferences: false,
+        sync_agents: false,
+        sync_hooks: false,
+        sync_instructions: false,
+        sync_plugin_assets: true,
+        ..Default::default()
+    };
+
+    let report = orch.sync(&params).unwrap();
+    assert_eq!(
+        report.plugin_assets.written, 1,
+        "Dry run should report count"
+    );
+
+    // Nothing should be on disk
+    let cursor_plugin = setup
+        .cursor_dir
+        .path()
+        .join("plugins/cache/market/plugin/1.0.0");
+    assert!(!cursor_plugin.exists(), "Dry run should not create files");
+}

--- a/crates/sync/tests/skills_sync_comprehensive.rs
+++ b/crates/sync/tests/skills_sync_comprehensive.rs
@@ -233,6 +233,7 @@ mod basic_sync_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -271,6 +272,7 @@ mod basic_sync_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -314,6 +316,7 @@ mod basic_sync_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -354,6 +357,7 @@ mod basic_sync_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -396,6 +400,7 @@ mod basic_sync_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -437,6 +442,7 @@ mod basic_sync_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -1344,6 +1350,7 @@ mod case_sensitivity_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);

--- a/crates/sync/tests/sync_integration.rs
+++ b/crates/sync/tests/sync_integration.rs
@@ -136,6 +136,7 @@ mod sync_direction_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         // Perform sync
@@ -189,6 +190,7 @@ mod sync_direction_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -243,6 +245,7 @@ mod sync_skip_existing_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         // Debug: Show what commands are being synced
@@ -312,6 +315,7 @@ mod sync_dry_run_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -382,6 +386,7 @@ mod sync_force_overwrite_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -431,6 +436,7 @@ mod sync_error_handling_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);
@@ -474,6 +480,7 @@ mod sync_error_handling_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source, target);

--- a/crates/sync/tests/sync_skip_existing_tests.rs
+++ b/crates/sync/tests/sync_skip_existing_tests.rs
@@ -137,6 +137,7 @@ mod skip_existing_commands_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source_adapter, target_adapter);
@@ -185,6 +186,7 @@ mod skip_existing_commands_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source_adapter, target_adapter);
@@ -255,6 +257,7 @@ mod skip_existing_commands_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source_adapter, target_adapter);
@@ -310,6 +313,7 @@ mod skip_existing_commands_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source_adapter, target_adapter);
@@ -370,6 +374,7 @@ mod skip_existing_commands_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source_adapter, target_adapter);
@@ -415,6 +420,7 @@ mod skip_existing_commands_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source_adapter, target_adapter);
@@ -465,6 +471,7 @@ mod skip_existing_commands_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         // Sync from Codex (new source) to Claude (new target)
@@ -521,6 +528,7 @@ mod skip_existing_commands_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source_adapter, target_adapter);
@@ -574,6 +582,7 @@ mod skip_existing_commands_tests {
             sync_instructions: true,
             skip_existing_instructions: false,
             include_marketplace: false,
+            sync_plugin_assets: false,
         };
 
         let orchestrator = SyncOrchestrator::new(source_adapter, target_adapter);

--- a/crates/test-utils/Cargo.toml
+++ b/crates/test-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills_test_utils"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 license = "Apache-2.0"
 description = "Shared test utilities for skrills crates"

--- a/crates/tome/Cargo.toml
+++ b/crates/tome/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-tome"
-version = "0.7.5"
+version = "0.7.6"
 edition = "2021"
 description = "Research API orchestration, caching, and knowledge graph for skrills."
 license = "MIT"

--- a/crates/tome/src/cache.rs
+++ b/crates/tome/src/cache.rs
@@ -123,10 +123,11 @@ impl ResearchCache {
         &self.pdf_dir
     }
 
-    /// Returns the canonical skrills-tome cache directory, creating it if needed.
+    /// Returns the standard skrills-tome cache directory, creating it if needed.
     ///
-    /// Other modules (knowledge graph, citations) should use this instead of
-    /// duplicating the path logic.
+    /// Callers that need the cache path (e.g., server handlers constructing
+    /// database paths for the knowledge graph or citation tracker) should use
+    /// this instead of duplicating the path logic.
     pub fn cache_dir() -> TomeResult<std::path::PathBuf> {
         let base = dirs::cache_dir()
             .or_else(|| dirs::home_dir().map(|h| h.join(".cache")))

--- a/crates/tome/src/citations.rs
+++ b/crates/tome/src/citations.rs
@@ -219,4 +219,99 @@ mod tests {
         ct.add_citation("p2", "p1", None).unwrap();
         assert_eq!(ct.stats().unwrap(), (2, 1));
     }
+
+    #[test]
+    fn duplicate_citation_is_ignored() {
+        let ct = CitationTracker::open_in_memory().unwrap();
+        ct.track_paper(&test_paper("p1", "Original")).unwrap();
+        ct.track_paper(&test_paper("p2", "Citing")).unwrap();
+
+        ct.add_citation("p2", "p1", Some("first insert")).unwrap();
+        // Second insert with same IDs should be silently ignored
+        ct.add_citation("p2", "p1", Some("duplicate")).unwrap();
+
+        let fwd = ct.forward_citations("p1").unwrap();
+        assert_eq!(fwd.len(), 1, "duplicate citation should be ignored");
+        assert_eq!(
+            fwd[0].context.as_deref(),
+            Some("first insert"),
+            "original context should be preserved"
+        );
+    }
+
+    #[test]
+    fn upsert_updates_existing_paper() {
+        let ct = CitationTracker::open_in_memory().unwrap();
+        ct.track_paper(&test_paper("p1", "Original Title")).unwrap();
+
+        // Track same paper ID with updated title
+        let updated = Paper {
+            id: "p1".to_string(),
+            title: "Updated Title".to_string(),
+            authors: vec![],
+            abstract_text: None,
+            year: Some(2025),
+            doi: Some("10.1234/p1".to_string()),
+            url: None,
+            source: PaperSource::SemanticScholar,
+            citation_count: Some(100),
+            pdf_url: None,
+        };
+        ct.track_paper(&updated).unwrap();
+
+        let papers = ct.tracked_papers().unwrap();
+        assert_eq!(papers.len(), 1, "upsert should not create duplicate");
+        assert_eq!(papers[0].1, "Updated Title");
+        assert_eq!(papers[0].2, Some(100));
+    }
+
+    #[test]
+    fn empty_tracker_returns_empty_results() {
+        let ct = CitationTracker::open_in_memory().unwrap();
+        assert!(ct.forward_citations("nonexistent").unwrap().is_empty());
+        assert!(ct.backward_citations("nonexistent").unwrap().is_empty());
+        assert!(ct.tracked_papers().unwrap().is_empty());
+    }
+
+    #[test]
+    fn multiple_forward_citations() {
+        let ct = CitationTracker::open_in_memory().unwrap();
+        ct.track_paper(&test_paper("original", "Seminal Paper"))
+            .unwrap();
+        ct.track_paper(&test_paper("c1", "Citing A")).unwrap();
+        ct.track_paper(&test_paper("c2", "Citing B")).unwrap();
+        ct.track_paper(&test_paper("c3", "Citing C")).unwrap();
+
+        ct.add_citation("c1", "original", None).unwrap();
+        ct.add_citation("c2", "original", None).unwrap();
+        ct.add_citation("c3", "original", None).unwrap();
+
+        let fwd = ct.forward_citations("original").unwrap();
+        assert_eq!(fwd.len(), 3, "should have 3 forward citations");
+
+        // Original paper should have no backward citations
+        let bwd = ct.backward_citations("original").unwrap();
+        assert!(bwd.is_empty());
+    }
+
+    #[test]
+    fn tracked_papers_ordered_by_citation_count() {
+        let ct = CitationTracker::open_in_memory().unwrap();
+
+        let mut low = test_paper("low", "Low Citations");
+        low.citation_count = Some(5);
+        let mut high = test_paper("high", "High Citations");
+        high.citation_count = Some(500);
+        let mut mid = test_paper("mid", "Mid Citations");
+        mid.citation_count = Some(50);
+
+        ct.track_paper(&low).unwrap();
+        ct.track_paper(&high).unwrap();
+        ct.track_paper(&mid).unwrap();
+
+        let papers = ct.tracked_papers().unwrap();
+        assert_eq!(papers[0].0, "high");
+        assert_eq!(papers[1].0, "mid");
+        assert_eq!(papers[2].0, "low");
+    }
 }

--- a/crates/tome/src/knowledge_graph.rs
+++ b/crates/tome/src/knowledge_graph.rs
@@ -6,6 +6,7 @@
 use crate::{TomeError, TomeResult};
 use rusqlite::Connection;
 use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
 use time::OffsetDateTime;
 
 /// Node types in the knowledge graph.
@@ -209,7 +210,7 @@ impl KnowledgeGraph {
                         .map_err(|e| rusqlite::Error::InvalidColumnName(format!("{e}")))?,
                     label: row.get(2)?,
                     metadata_json: row.get(3)?,
-                    created_at: parse_rfc3339(row.get::<_, String>(4)?.as_str())
+                    created_at: parse_timestamp(row.get::<_, String>(4)?.as_str())
                         .map_err(|e| rusqlite::Error::InvalidColumnName(format!("{e}")))?,
                 })
             },
@@ -237,7 +238,7 @@ impl KnowledgeGraph {
                         .map_err(|e| rusqlite::Error::InvalidColumnName(format!("{e}")))?,
                         label: row.get(2)?,
                         metadata_json: row.get(3)?,
-                        created_at: parse_rfc3339(row.get::<_, String>(4)?.as_str())
+                        created_at: parse_timestamp(row.get::<_, String>(4)?.as_str())
                             .map_err(|e| rusqlite::Error::InvalidColumnName(format!("{e}")))?,
                     })
                 })?;
@@ -253,7 +254,7 @@ impl KnowledgeGraph {
                     .map_err(|e| rusqlite::Error::InvalidColumnName(format!("{e}")))?,
                 label: row.get(2)?,
                 metadata_json: row.get(3)?,
-                created_at: parse_rfc3339(row.get::<_, String>(4)?.as_str())
+                created_at: parse_timestamp(row.get::<_, String>(4)?.as_str())
                     .map_err(|e| rusqlite::Error::InvalidColumnName(format!("{e}")))?,
             })
         })?;
@@ -310,18 +311,22 @@ impl KnowledgeGraph {
     }
 }
 
+/// Legacy SQLite `datetime('now')` format: `YYYY-MM-DD HH:MM:SS`
+static LEGACY_TIMESTAMP_FMT: LazyLock<Vec<time::format_description::FormatItem<'static>>> =
+    LazyLock::new(|| {
+        time::format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second]")
+            .expect("static format description")
+    });
+
 /// Parse a timestamp string from SQLite TEXT storage into `OffsetDateTime`.
 ///
 /// Accepts RFC 3339 (`2026-04-08T12:00:00Z`) and falls back to SQLite's
 /// `datetime('now')` format (`2026-04-08 12:00:00`) for databases created
 /// before the 0.7.5 migration.  Fallback timestamps are treated as UTC.
-fn parse_rfc3339(s: &str) -> TomeResult<OffsetDateTime> {
+fn parse_timestamp(s: &str) -> TomeResult<OffsetDateTime> {
     OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339).or_else(|_| {
-        // Legacy SQLite datetime format: "YYYY-MM-DD HH:MM:SS" (no timezone)
-        let fmt = time::format_description::parse("[year]-[month]-[day] [hour]:[minute]:[second]")
-            .expect("static format description");
-        tracing::warn!("Parsing legacy timestamp format: '{s}' — consider re-inserting the node to migrate");
-        time::PrimitiveDateTime::parse(s, &fmt)
+        tracing::debug!("Parsing legacy timestamp format: '{s}'");
+        time::PrimitiveDateTime::parse(s, &LEGACY_TIMESTAMP_FMT)
             .map(|dt| dt.assume_utc())
     })
     .map_err(|e| TomeError::Other(format!("invalid timestamp '{s}': {e}")))
@@ -472,12 +477,12 @@ mod tests {
     }
 
     /// GIVEN a timestamp in SQLite's datetime('now') format
-    /// WHEN parse_rfc3339 is called
+    /// WHEN parse_timestamp is called
     /// THEN it falls back to the legacy format and returns a valid OffsetDateTime
     #[test]
-    fn parse_rfc3339_accepts_legacy_sqlite_format() {
+    fn parse_timestamp_accepts_legacy_sqlite_format() {
         let legacy = "2025-12-15 10:30:00";
-        let dt = parse_rfc3339(legacy).expect("should parse legacy format");
+        let dt = parse_timestamp(legacy).expect("should parse legacy format");
         assert_eq!(dt.year(), 2025);
         assert_eq!(dt.month() as u8, 12);
         assert_eq!(dt.day(), 15);
@@ -486,12 +491,12 @@ mod tests {
     }
 
     /// GIVEN a timestamp in RFC 3339 format
-    /// WHEN parse_rfc3339 is called
+    /// WHEN parse_timestamp is called
     /// THEN it parses without falling back
     #[test]
-    fn parse_rfc3339_accepts_rfc3339_format() {
+    fn parse_timestamp_accepts_rfc3339_format() {
         let rfc = "2026-04-08T12:00:00Z";
-        let dt = parse_rfc3339(rfc).expect("should parse RFC 3339");
+        let dt = parse_timestamp(rfc).expect("should parse RFC 3339");
         assert_eq!(dt.year(), 2026);
     }
 
@@ -505,5 +510,72 @@ mod tests {
         kg.add_edge("a", "b", EdgeKind::Extends, 1.0, None).unwrap();
 
         assert_eq!(kg.stats().unwrap(), (2, 1));
+    }
+
+    #[test]
+    fn get_nonexistent_node_returns_none() {
+        let kg = KnowledgeGraph::open_in_memory().unwrap();
+        assert!(kg.get_node("does-not-exist").unwrap().is_none());
+    }
+
+    #[test]
+    fn edge_upsert_updates_weight() {
+        let kg = KnowledgeGraph::open_in_memory().unwrap();
+        kg.add_node("a", NodeKind::Paper, "Paper A", None).unwrap();
+        kg.add_node("b", NodeKind::Paper, "Paper B", None).unwrap();
+
+        kg.add_edge("a", "b", EdgeKind::Cites, 0.5, None).unwrap();
+        // Upsert same edge with higher weight
+        kg.add_edge(
+            "a",
+            "b",
+            EdgeKind::Cites,
+            0.9,
+            Some(r#"{"reason":"stronger link"}"#),
+        )
+        .unwrap();
+
+        let edges = kg.edges_from("a").unwrap();
+        assert_eq!(edges.len(), 1, "upsert should not create duplicate edge");
+        assert!((edges[0].weight - 0.9).abs() < f64::EPSILON);
+        assert_eq!(
+            edges[0].metadata_json.as_deref(),
+            Some(r#"{"reason":"stronger link"}"#)
+        );
+    }
+
+    #[test]
+    fn multiple_edge_types_between_same_nodes() {
+        let kg = KnowledgeGraph::open_in_memory().unwrap();
+        kg.add_node("a", NodeKind::Paper, "Paper A", None).unwrap();
+        kg.add_node("b", NodeKind::Paper, "Paper B", None).unwrap();
+
+        // Same node pair, different edge types (PK is source_id + target_id + kind)
+        kg.add_edge("a", "b", EdgeKind::Cites, 1.0, None).unwrap();
+        kg.add_edge("a", "b", EdgeKind::Extends, 0.8, None).unwrap();
+        kg.add_edge("a", "b", EdgeKind::Contradicts, 0.3, None)
+            .unwrap();
+
+        let edges = kg.edges_from("a").unwrap();
+        assert_eq!(edges.len(), 3, "different edge types should coexist");
+
+        let incoming = kg.edges_to("b").unwrap();
+        assert_eq!(incoming.len(), 3);
+    }
+
+    #[test]
+    fn edges_from_nonexistent_node_returns_empty() {
+        let kg = KnowledgeGraph::open_in_memory().unwrap();
+        assert!(kg.edges_from("ghost").unwrap().is_empty());
+        assert!(kg.edges_to("ghost").unwrap().is_empty());
+    }
+
+    #[test]
+    fn search_no_matches_returns_empty() {
+        let kg = KnowledgeGraph::open_in_memory().unwrap();
+        kg.add_node("t-1", NodeKind::Topic, "machine learning", None)
+            .unwrap();
+        let results = kg.search_nodes("quantum", None).unwrap();
+        assert!(results.is_empty());
     }
 }

--- a/crates/tome/src/knowledge_graph.rs
+++ b/crates/tome/src/knowledge_graph.rs
@@ -324,12 +324,12 @@ static LEGACY_TIMESTAMP_FMT: LazyLock<Vec<time::format_description::FormatItem<'
 /// `datetime('now')` format (`2026-04-08 12:00:00`) for databases created
 /// before the 0.7.5 migration.  Fallback timestamps are treated as UTC.
 fn parse_timestamp(s: &str) -> TomeResult<OffsetDateTime> {
-    OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339).or_else(|_| {
-        tracing::debug!("Parsing legacy timestamp format: '{s}'");
-        time::PrimitiveDateTime::parse(s, &LEGACY_TIMESTAMP_FMT)
-            .map(|dt| dt.assume_utc())
-    })
-    .map_err(|e| TomeError::Other(format!("invalid timestamp '{s}': {e}")))
+    OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339)
+        .or_else(|_| {
+            tracing::debug!("Parsing legacy timestamp format: '{s}'");
+            time::PrimitiveDateTime::parse(s, &LEGACY_TIMESTAMP_FMT).map(|dt| dt.assume_utc())
+        })
+        .map_err(|e| TomeError::Other(format!("invalid timestamp '{s}': {e}")))
 }
 
 fn parse_node_kind(s: &str) -> TomeResult<NodeKind> {

--- a/crates/validate/Cargo.toml
+++ b/crates/validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skrills-validate"
-version = "0.7.5"
+version = "0.7.6"
 edition.workspace = true
 description = "Skill validation for Claude Code and Codex CLI"
 license = "MIT"

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## 0.7.6 - 2026-04-12
 - **NEW: Plugin Assets Sync**: Cursor sync now mirrors plugin runtime scripts (Python, shell), binaries, and source packages from `~/.claude/plugins/cache/` to `~/.cursor/plugins/cache/`. Preserves directory hierarchy so skills can reference companion scripts at the same relative paths. Controlled by the `sync_plugin_assets` flag in `SyncParams` (default: enabled).
 - **NEW: `PluginAsset` Type**: Added `PluginAsset` struct to the sync common schema, with publisher, plugin name, version, relative path, content, hash, and executable permission tracking.
-- **NEW: Claude Adapter `read_plugin_assets()`**: Walks the plugin cache collecting files from `scripts/`, `bin/`, `hooks/`, `src/`, and config files. Excludes directories already handled by other sync paths (`skills/`, `commands/`, `agents/`) and runtime artifacts (`tests/`, `.venv/`, `__pycache__/`, `node_modules/`).
+- **NEW: Claude Adapter `read_plugin_assets()`**: Walks the plugin cache collecting all files except those handled by other sync paths (`skills/`, `commands/`, `agents/`) and runtime artifacts (`tests/`, `.venv/`, `__pycache__/`, `node_modules/`, `.git/`). This captures scripts, binaries, hooks, source packages, and config files.
 - **NEW: Cursor Adapter `write_plugin_assets()`**: Writes plugin assets to `~/.cursor/plugins/cache/` mirroring the Claude structure. Supports hash-based change detection and preserves executable permissions on Unix.
 - **Testing**: Added 18 tests covering plugin asset read/write, exclusion rules, version picking, executable detection, serialization roundtrip, report totals, and integration flows (dry-run, unchanged detection, hierarchy preservation).
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 0.7.6 - 2026-04-12
+- **NEW: Plugin Assets Sync**: Cursor sync now mirrors plugin runtime scripts (Python, shell), binaries, and source packages from `~/.claude/plugins/cache/` to `~/.cursor/plugins/cache/`. Preserves directory hierarchy so skills can reference companion scripts at the same relative paths. Controlled by the `sync_plugin_assets` flag in `SyncParams` (default: enabled).
+- **NEW: `PluginAsset` Type**: Added `PluginAsset` struct to the sync common schema, with publisher, plugin name, version, relative path, content, hash, and executable permission tracking.
+- **NEW: Claude Adapter `read_plugin_assets()`**: Walks the plugin cache collecting files from `scripts/`, `bin/`, `hooks/`, `src/`, and config files. Excludes directories already handled by other sync paths (`skills/`, `commands/`, `agents/`) and runtime artifacts (`tests/`, `.venv/`, `__pycache__/`, `node_modules/`).
+- **NEW: Cursor Adapter `write_plugin_assets()`**: Writes plugin assets to `~/.cursor/plugins/cache/` mirroring the Claude structure. Supports hash-based change detection and preserves executable permissions on Unix.
+- **Testing**: Added 18 tests covering plugin asset read/write, exclusion rules, version picking, executable detection, serialization roundtrip, report totals, and integration flows (dry-run, unchanged detection, hierarchy preservation).
+
 ## 0.7.5 - 2026-04-07
 - **Fix: Cursor Skill Descriptions**: Cursor adapter now preserves skill `description` as a plain-text first line instead of discarding it. Handles YAML block scalars (`>-`, `>`, `|-`, `|`), multi-line quoted strings, and strips surrounding quotes. `model_hint` remains as an HTML comment. Cursor shows the description as the skill subtitle instead of `<!-- model_hint: ... -->`.
 - **Refactor: Research Handlers**: Hoisted function-level imports to module scope in `research.rs`, reducing per-call overhead and improving readability.

--- a/plugins/skrills/.claude-plugin/plugin.json
+++ b/plugins/skrills/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "skrills",
-  "version": "0.7.5",
+  "version": "0.7.6",
   "description": "Skill synchronization and management for Claude Code, Codex, GitHub Copilot, and Cursor. Provides 36 MCP tools for validation, sync, intelligence, research, and tracing.",
   "author": {
     "name": "skrills",


### PR DESCRIPTION
## Summary

- Add plugin asset sync (scripts, binaries, hooks) from Claude to Cursor with path traversal protection
- Refactor research tool handlers: centralize cache dir, deduplicate enum parsing via serde, add error handling improvements
- Preserve skill description and model_hint when syncing to Cursor adapter
- Normalize snake_case tool names to kebab-case in MCP handler
- Migrate knowledge graph `created_at` from String to OffsetDateTime with legacy fallback
- Bump all workspace crates from 0.7.4 to 0.7.6

## Test plan

- [ ] Fix flaky `read_plugin_assets_picks_latest_version` test (mtime-based, fails on WSL2)
- [ ] Run `cargo test --workspace` — all tests green
- [ ] Manual test: Claude→Cursor sync with real plugin cache
- [ ] Verify pre-0.7.5 knowledge graph databases load with legacy timestamp fallback
- [ ] Test snake_case tool names from MCP client